### PR TITLE
Custom react/require-default-props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,6 +95,13 @@
     "react/jsx-indent": "warn",
     "no-unreachable": "warn",
     "object-curly-newline": "warn",
-    "no-trailing-spaces": "warn"
+    "no-trailing-spaces": "warn",
+    "react/require-default-props": [
+      "warn",
+      {
+        "forbidDefaultForRequired": true,
+        "ignoreFunctionalComponents": true
+      }
+    ]
   }
 }

--- a/src/components/SearchBox/SearchInput.tsx
+++ b/src/components/SearchBox/SearchInput.tsx
@@ -84,7 +84,7 @@ const SearchInput = ({
   value,
   onChange,
   onClear,
-  disabled,
+  disabled = false,
 }: Props) => {
   return (
     <Container>
@@ -109,10 +109,6 @@ const SearchInput = ({
       )}
     </Container>
   )
-}
-
-SearchInput.defaultProps = {
-  disabled: false,
 }
 
 export default SearchInput


### PR DESCRIPTION
Few things:

1. I use "warn", not "error". Hate when shait like this interrupts prototyping.
2. I forbid default props for required props – makes more sense.
3. I ignore defaultProps requirement in functional components – also makes more sense cause props can have their defaults assigned to them right away (in func definition).

Cheers!