### PR TITLE
[FRONT-186] Network explorer search box long result list breaks layout

### DIFF
--- a/src/components/SearchBox/SearchResults.tsx
+++ b/src/components/SearchBox/SearchResults.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
@@ -7,15 +7,25 @@ import { SearchResult } from '../../utils/api/streamr'
 
 const Container = styled.div`
   display: grid;
+  max-height: 280px;
+  overflow: scroll;
+
+  a,
+  a:hover,
+  a:active,
+  a:visited {
+    text-decoration: none;
+  }
 `
 
 const Row = styled.div`
   display: grid;
-  grid-template-columns: 40px 1fr;
-  height: 40px;
+  grid-template-columns: 64px 1fr;
+  height: 64px;
   font-size: 12px;
   line-height: 16px;
   cursor: pointer;
+  color: #CDCDCD;
 
   &:hover {
     background: #F5F5F5;
@@ -27,47 +37,85 @@ const Icon = styled.div`
   justify-self: center;
 `
 
-const Description = styled.div`
+const Item = styled.div`
   align-self: center;
   overflow: hidden;
   text-overflow: ellipsis;
   padding-right: 12px;
+  white-space: nowrap;
+
+  span:first-child {
+      color: #323232;
+      font-weight: 500;
+  }
+
+  span + span {
+    margin-left: 8px;
+  }
 `
 
 type Props = {
   results: Array<SearchResult>,
 }
 
-const Stream = ({ id, type, name }: SearchResult) => (
-  <Row as={Link} to={`/streams/${encodeURIComponent(id)}`}>
-    <Icon>
-      <StreamIcon />
-    </Icon>
-    <Description>
-      {name}
-    </Description>
-  </Row>
-)
+const Stream = ({
+  id,
+  type,
+  name: nameProp,
+  description,
+}: SearchResult) => {
+  const name = useMemo(() => {
+    if (nameProp.indexOf('0x') === 0) {
+      return nameProp.replace(/^0x([A-Fa-f0-9]{3})[A-Fa-f0-9]*([A-Fa-f0-9]{5})/, '0x$1...$2')
+    }
 
-const Node = ({ id, type, name }: SearchResult) => (
+    return nameProp
+  }, [nameProp])
+
+  return (
+    <Row as={Link} to={`/streams/${encodeURIComponent(id)}`}>
+      <Icon>
+        <StreamIcon />
+      </Icon>
+      <Item>
+        <span>{name}</span>
+        <span>{description}</span>
+      </Item>
+    </Row>
+  )
+}
+
+const Node = ({
+  id,
+  type,
+  name,
+  description,
+}: SearchResult) => (
   <Row as={Link} to={`/nodes/${id}`}>
     <Icon>
       <NodeIcon />
     </Icon>
-    <Description>
-      {name}
-    </Description>
+    <Item>
+      <span>{name}</span>
+      <span>{description}</span>
+    </Item>
   </Row>
 )
 
-const Location = ({ id, type, name }: SearchResult) => (
+const Location = ({
+  id,
+  type,
+  name,
+  description,
+}: SearchResult) => (
   <Row>
     <Icon>
       <LocationIcon />
     </Icon>
-    <Description>
-      {name}
-    </Description>
+    <Item>
+      <span>{name}</span>
+      <span>{description}</span>
+    </Item>
   </Row>
 )
 

--- a/src/components/SearchBox/useSearch.test.tsx
+++ b/src/components/SearchBox/useSearch.test.tsx
@@ -86,6 +86,7 @@ describe('useSearch', () => {
 
     expect(search.results).toStrictEqual([{
       id: '3',
+      description: '3',
       type: 'nodes',
       name: 'New York',
     }])
@@ -107,8 +108,9 @@ describe('useSearch', () => {
     })
     const streamSearchMock = jest.fn(() => Promise.resolve([{
       id: '2',
-      title: 'Stream',
+      name: 'Stream',
       type: 'streams',
+      description: 'My Stream',
     }]))
     streamrApi.searchStreams.mockImplementation(streamSearchMock)
     mapApi.getLocations.mockResolvedValue([])
@@ -125,12 +127,14 @@ describe('useSearch', () => {
     })
     expect(search.results).toStrictEqual([{
       id: '1',
+      description: '1',
       type: 'nodes',
       name: 'Berlin',
     }, {
       id: '2',
-      title: 'Stream',
+      name: 'Stream',
       type: 'streams',
+      description: 'My Stream',
     }])
   })
 
@@ -150,7 +154,8 @@ describe('useSearch', () => {
     })
     const getLocationsMock = jest.fn(() => Promise.resolve([{
       id: 'places.abc123',
-      title: 'Berlin, Germany',
+      name: 'Berlin',
+      description: 'Berlin, Germany',
       type: 'locations',
     }]))
     mapApi.getLocations.mockImplementation(getLocationsMock)
@@ -168,11 +173,13 @@ describe('useSearch', () => {
     })
     expect(search.results).toStrictEqual([{
       id: '1',
+      description: '1',
       type: 'nodes',
       name: 'Berlin',
     }, {
       id: 'places.abc123',
-      title: 'Berlin, Germany',
+      name: 'Berlin',
+      description: 'Berlin, Germany',
       type: 'locations',
     }])
   })

--- a/src/components/SearchBox/useSearch.ts
+++ b/src/components/SearchBox/useSearch.ts
@@ -34,6 +34,7 @@ const useSearch = () => {
       id,
       type: 'nodes',
       name: title,
+      description: id,
     })), [nodes])
 
   const debouncedUpdateResults = useDebounced(

--- a/src/utils/api/mapbox.ts
+++ b/src/utils/api/mapbox.ts
@@ -10,6 +10,7 @@ const getPlacesUrl = ({ place }: { place: string}) => (
 
 type GeoCodeResultFeature = {
   id: string,
+  text: string,
   place_type: Array<string>,
   place_name: string,
   bbox: Array<number>,
@@ -77,9 +78,10 @@ export const getLocations = async ({ search }: LocationSearch): Promise<SearchRe
 
   return (result && result.features || [])
     .filter(({ place_type }) => place_type.includes('place'))
-    .map(({ id, place_name }) => ({
+    .map(({ id, text, place_name }) => ({
       id,
-      name: place_name,
+      name: text,
+      description: place_name,
       type: 'locations',
     }))
 }

--- a/src/utils/api/streamr.ts
+++ b/src/utils/api/streamr.ts
@@ -11,6 +11,7 @@ export type SearchResult = {
   type: 'streams' | 'nodes' | 'locations',
   id: string,
   name: string,
+  description?: string,
 }
 
 export const searchStreams = async ({ search = '' }: SearchStreams): Promise<SearchResult[]> => {
@@ -37,10 +38,11 @@ export const searchStreams = async ({ search = '' }: SearchStreams): Promise<Sea
   ], 'id')
 
   return results
-    .map(({ id }: Stream) => ({
+    .map(({ id, description }: Stream) => ({
       type: 'streams',
       id,
       name: id,
+      description,
     }))
 }
 
@@ -51,6 +53,7 @@ type GetStream = {
 export type Stream = {
   id: string,
   name: string,
+  description: string,
 }
 
 type GetStreams = {


### PR DESCRIPTION
Update search box so that it handles overflow + styled list items.

![Screenshot 2020-12-08 at 15 00 32](https://user-images.githubusercontent.com/1064982/101487137-66424a80-3966-11eb-94d0-fce62912f2e5.png)
