### PR TITLE
[FRONT-195] Show all nodes in default view

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,6 +47,7 @@ const App = () => (
                 <Route exact path="/streams/:streamId/nodes/:nodeId" component={Stream} />
                 <Route exact path="/streams/:streamId" component={Stream} />
                 <Route exact path="/nodes/:nodeId" component={Node} />
+                <Route exact path="/" component={Node} />
               </Switch>
             </ErrorBoundary>
           </Layout>

--- a/src/components/Node/TopologyList.tsx
+++ b/src/components/Node/TopologyList.tsx
@@ -1,21 +1,46 @@
-import React from 'react'
+import React, { useCallback } from 'react'
+import { useHistory } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
 import NodeList from '../NodeList'
 
 type Props = {
-  id: string,
+  id?: string,
 }
 
 const TopologyList = ({ id }: Props) => {
-  const { visibleNodes } = useStore()
+  const { nodes, env } = useStore()
+
+  const history = useHistory()
+
+  const onNodeClick = useCallback((nodeId) => {
+    let path = '/'
+
+    if (id !== nodeId) {
+      path += `nodes/${nodeId}`
+    }
+
+    history.replace(path)
+  }, [id, history])
 
   return (
     <NodeList
-      nodes={visibleNodes}
+      nodes={nodes}
       activeNodeId={id}
-      onNodeClick={() => {}}
-    />
+      onNodeClick={onNodeClick}
+    >
+      <NodeList.Header>
+        Showing all
+        {' '}
+        <strong>{nodes.length}</strong>
+        {' '}
+        nodes in the
+        {' '}
+        <strong>{env && env.toUpperCase()}</strong>
+        {' '}
+        network
+      </NodeList.Header>
+    </NodeList>
   )
 }
 

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -5,21 +5,25 @@ import { useStore } from '../../contexts/Store'
 import TopologyList from './TopologyList'
 
 type NodeProps = {
-  id: string,
+  activeNodeId: string,
 }
 
-const ActiveNode = ({ id }: NodeProps) => {
+const AllNodes = ({ activeNodeId }: NodeProps) => {
   const { setTopology } = useStore()
+  const { nodes } = useStore()
 
   useEffect(() => {
-    setTopology({
+    const topology = nodes.reduce((result, { id }) => ({
+      ...result,
       [id]: [],
-    }, id)
+    }), {})
+
+    setTopology(topology, activeNodeId)
 
     return () => {
       setTopology({})
     }
-  }, [id, setTopology])
+  }, [nodes, setTopology, activeNodeId])
 
   return null
 }
@@ -28,13 +32,13 @@ export default () => {
   const { nodeId } = useParams()
   const { nodes } = useStore()
 
-  if (!nodeId || !nodes || nodes.length < 1) {
+  if (!nodes || nodes.length < 1) {
     return null
   }
 
   return (
     <div>
-      <ActiveNode id={nodeId} />
+      <AllNodes activeNodeId={nodeId} />
       <TopologyList id={nodeId} />
     </div>
   )

--- a/src/components/NodeList/index.tsx
+++ b/src/components/NodeList/index.tsx
@@ -5,6 +5,7 @@ import ControlBox from '../ControlBox'
 
 import NodeListItem from './NodeListItem'
 import * as api from '../../utils/api/tracker'
+import { SANS, MEDIUM } from '../../utils/styled'
 
 const Wrapper = styled.div`
   padding: 16px;
@@ -17,6 +18,23 @@ type Props = {
   onNodeClick?: (v: string) => void,
   children?: React.ReactNode,
 }
+
+const Header = styled.div`
+  font-family: ${SANS};
+  color: #A3A3A3;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  & + * {
+    margin-top: 16px;
+  }
+
+  strong {
+    font-weight: ${MEDIUM};
+  }
+`
 
 const NodeList = ({
   nodes,
@@ -48,5 +66,7 @@ const NodeList = ({
     </ControlBox>
   )
 }
+
+NodeList.Header = Header
 
 export default NodeList

--- a/src/components/Stream/TopologyList.tsx
+++ b/src/components/Stream/TopologyList.tsx
@@ -1,27 +1,8 @@
 import React, { useCallback } from 'react'
-import styled from 'styled-components/macro'
 import { useParams, useHistory } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
-import { SANS, MEDIUM } from '../../utils/styled'
 import NodeList from '../NodeList'
-
-const Header = styled.div`
-  font-family: ${SANS};
-  color: #A3A3A3;
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  & + * {
-    margin-top: 16px;
-  }
-
-  strong {
-    font-weight: ${MEDIUM};
-  }
-`
 
 type Props = {
   id: string,
@@ -50,7 +31,7 @@ const TopologyList = ({ id }: Props) => {
       activeNodeId={activeNodeId}
       onNodeClick={toggleNode}
     >
-      <Header>
+      <NodeList.Header>
         Showing
         {' '}
         <strong>{visibleNodes.length}</strong>
@@ -58,7 +39,7 @@ const TopologyList = ({ id }: Props) => {
         nodes carrying the stream
         {' '}
         <strong title={id}>{streamTitle}</strong>
-      </Header>
+      </NodeList.Header>
     </NodeList>
   )
 }

--- a/src/contexts/Controller.tsx
+++ b/src/contexts/Controller.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useState,
 } from 'react'
+import { useHistory } from 'react-router-dom'
 
 import * as trackerApi from '../utils/api/tracker'
 import * as streamrApi from '../utils/api/streamr'
@@ -40,6 +41,7 @@ function useControllerContext() {
   const { wrap: wrapStreams } = usePending('streams')
   const [hasLoaded, setHasLoaded] = useState(false)
   const isMounted = useIsMounted()
+  const history = useHistory()
 
   const loadTrackers = useCallback(() => (
     wrapTrackers(async () => {
@@ -126,8 +128,9 @@ function useControllerContext() {
     setEnvironment(env)
     resetStore()
     setHasLoaded(false)
+    history.push('/')
     loadTrackers()
-  }, [resetStore, loadTrackers])
+  }, [resetStore, loadTrackers, history])
 
   return useMemo(() => ({
     changeEnv,


### PR DESCRIPTION
Add default display of all nodes on the map when nothing is selected.

![Screenshot 2020-12-11 at 15 04 09](https://user-images.githubusercontent.com/1064982/101906751-25467200-3bc2-11eb-9921-8fb2d1c6509c.png)

Also should fix zooming issue ([FRONT-196](https://linear.app/streamr/issue/FRONT-196/zoom-levels-for-nodes-are-too-high)), basically when `activeNode` is defined it should react to that and when not, it should zoom the topology into view.