### PR TITLE
[FRONT-200] Load default view topology

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,22 @@
       "last 1 safari version"
     ]
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!<rootDir>/node_modules/",
+      "!*.stories.*"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    },
+    "coverageReporters": ["text"]
+  },
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@storybook/addon-actions": "^6.0.21",

--- a/package.json
+++ b/package.json
@@ -64,10 +64,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 70,
-        "functions": 70,
-        "lines": 70,
-        "statements": 70
+        "lines": 50
       }
     },
     "coverageReporters": ["text"]

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../../contexts/Store'
 import { useController } from '../../contexts/Controller'
 import TopologyList from './TopologyList'
 
-const TopologyUnionLoader = () => {
+const NodeConnectionsLoader = () => {
   const { loadTopology, resetTopology } = useController()
 
   useEffect(() => {
@@ -45,7 +45,7 @@ export default () => {
 
   return (
     <div>
-      <TopologyUnionLoader />
+      <NodeConnectionsLoader />
       <ActiveNodeSetter id={nodeId} />
       <TopologyList id={nodeId} />
     </div>

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -2,28 +2,35 @@ import React, { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
+import { useController } from '../../contexts/Controller'
 import TopologyList from './TopologyList'
 
-type NodeProps = {
-  activeNodeId: string,
-}
-
-const AllNodes = ({ activeNodeId }: NodeProps) => {
-  const { setTopology } = useStore()
-  const { nodes } = useStore()
+const TopologyUnionLoader = () => {
+  const { loadTopology, resetTopology } = useController()
 
   useEffect(() => {
-    const topology = nodes.reduce((result, { id }) => ({
-      ...result,
-      [id]: [],
-    }), {})
-
-    setTopology(topology, activeNodeId)
+    loadTopology()
 
     return () => {
-      setTopology({})
+      resetTopology()
     }
-  }, [nodes, setTopology, activeNodeId])
+  }, [loadTopology, resetTopology])
+
+  return null
+}
+
+type NodeProps = {
+  id: string,
+}
+
+const ActiveNodeSetter = ({ id }: NodeProps) => {
+  const { setActiveNodeId } = useStore()
+
+  useEffect(() => {
+    setActiveNodeId(id)
+
+    return () => setActiveNodeId(undefined)
+  }, [id, setActiveNodeId])
 
   return null
 }
@@ -38,7 +45,8 @@ export default () => {
 
   return (
     <div>
-      <AllNodes activeNodeId={nodeId} />
+      <TopologyUnionLoader />
+      <ActiveNodeSetter id={nodeId} />
       <TopologyList id={nodeId} />
     </div>
   )

--- a/src/components/Stream/index.tsx
+++ b/src/components/Stream/index.tsx
@@ -14,7 +14,9 @@ const TopologyLoader = ({ id }: StreamProps) => {
   const { loadTopology, resetTopology } = useController()
 
   useEffect(() => {
-    loadTopology(id)
+    loadTopology({
+      streamId: id,
+    })
 
     return () => {
       resetTopology()
@@ -42,7 +44,7 @@ type NodeProps = {
   id: string,
 }
 
-const ActiveNode = ({ id }: NodeProps) => {
+const ActiveNodeSetter = ({ id }: NodeProps) => {
   const { setActiveNodeId } = useStore()
 
   useEffect(() => {
@@ -68,7 +70,7 @@ export default () => {
     <div>
       <TopologyLoader id={streamId} />
       <StreamLoader id={streamId} />
-      <ActiveNode id={nodeId} />
+      <ActiveNodeSetter id={nodeId} />
       <TopologyList id={streamId} />
     </div>
   )

--- a/src/contexts/Controller.test.jsx
+++ b/src/contexts/Controller.test.jsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+import * as trackerApi from '../utils/api/tracker'
+
+import { Provider as ControllerProvider, useController } from './Controller'
+import { Provider as StoreProvider, useStore } from './Store'
+import { Provider as PendingProvider } from './Pending'
+
+jest.mock('../utils/api/tracker')
+
+let container
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  document.body.removeChild(container)
+  container = null
+})
+
+describe('Controller', () => {
+  afterEach(() => {
+    trackerApi.getNodeConnections.mockClear()
+    trackerApi.getTopology.mockClear()
+  })
+
+  describe('loadTopology', () => {
+    it('loads connections for all nodes by default', async () => {
+      let store
+      let controller
+
+      function Test() {
+        store = useStore()
+        controller = useController()
+
+        return null
+      }
+
+      render((
+        <PendingProvider>
+          <StoreProvider>
+            <ControllerProvider>
+              <Test />
+            </ControllerProvider>
+          </StoreProvider>
+        </PendingProvider>
+      ), container)
+
+      expect(store.topology).toStrictEqual({})
+      expect(store.visibleNodes).toStrictEqual([])
+
+      const nextNodes = [{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '2',
+        title: 'Node 2',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }, {
+        id: '4',
+        title: 'Node 4',
+      }]
+
+      act(() => {
+        store.addNodes(nextNodes)
+      })
+
+      const nextTopology = {
+        '1': ['3', '4'],
+        '2': [],
+        '3': ['1'],
+        '4': ['1'],
+      }
+
+      const getNodeConnectionsMock = jest.fn().mockResolvedValue(nextTopology)
+      const getTopologyMock = jest.fn()
+      trackerApi.getNodeConnections.mockImplementation(getNodeConnectionsMock)
+      trackerApi.getTopology.mockImplementation(getTopologyMock)
+
+      await act(async () => {
+        await controller.loadTopology()
+      })
+
+      expect(getNodeConnectionsMock).toBeCalled()
+      expect(getTopologyMock).not.toBeCalled()
+      expect(store.topology).toStrictEqual(nextTopology)
+      expect(store.visibleNodes).toStrictEqual(nextNodes)
+    })
+
+    it('loads topology for a stream', async () => {
+      let store
+      let controller
+
+      function Test() {
+        store = useStore()
+        controller = useController()
+
+        return null
+      }
+
+      render((
+        <PendingProvider>
+          <StoreProvider>
+            <ControllerProvider>
+              <Test />
+            </ControllerProvider>
+          </StoreProvider>
+        </PendingProvider>
+      ), container)
+
+      expect(store.topology).toStrictEqual({})
+      expect(store.visibleNodes).toStrictEqual([])
+
+      const nextNodes = [{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '2',
+        title: 'Node 2',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }, {
+        id: '4',
+        title: 'Node 4',
+      }]
+
+      act(() => {
+        store.addNodes(nextNodes)
+      })
+
+      const nextTopology = {
+        '1': ['3'],
+        '2': ['3'],
+        '3': ['1', '2'],
+      }
+
+      const getNodeConnectionsMock = jest.fn()
+      const getTopologyMock = jest.fn().mockResolvedValue(nextTopology)
+      trackerApi.getNodeConnections.mockImplementation(getNodeConnectionsMock)
+      trackerApi.getTopology.mockImplementation(getTopologyMock)
+
+      await act(async () => {
+        await controller.loadTopology({
+          streamId: 'streamr.eth/stream-id',
+        })
+      })
+
+      expect(getNodeConnectionsMock).not.toBeCalled()
+      expect(getTopologyMock).toBeCalledWith({
+        id: 'streamr.eth/stream-id',
+      })
+      expect(store.topology).toStrictEqual(nextTopology)
+      expect(store.visibleNodes).toStrictEqual([{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '2',
+        title: 'Node 2',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }])
+    })
+  })
+})

--- a/src/contexts/Controller.tsx
+++ b/src/contexts/Controller.tsx
@@ -110,15 +110,35 @@ function useControllerContext() {
     }
   }, [])
 
-  const loadTopology = useCallback(async (streamId: string) => (
+  const loadTopologyUnionFromApi = useCallback(async () => {
+    try {
+      const nextTopology = await trackerApi.getTopologyUnion()
+
+      return nextTopology
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(e)
+      throw e
+    }
+  }, [])
+
+  const loadTopology = useCallback(async (options: { streamId?: string } = {}) => (
     wrapTopology(async () => {
-      const newTopology = await loadTopologyFromApi({ id: streamId })
+      const { streamId } = options || {}
+
+      let newTopology
+
+      if (streamId) {
+        newTopology = await loadTopologyFromApi({ id: streamId })
+      } else {
+        newTopology = await loadTopologyUnionFromApi()
+      }
 
       if (!isMounted()) { return }
 
       setTopology(newTopology)
     })
-  ), [wrapTopology, loadTopologyFromApi, setTopology, isMounted])
+  ), [wrapTopology, loadTopologyFromApi, loadTopologyUnionFromApi, setTopology, isMounted])
 
   const resetTopology = useCallback(() => {
     setTopology({})

--- a/src/contexts/Controller.tsx
+++ b/src/contexts/Controller.tsx
@@ -110,9 +110,9 @@ function useControllerContext() {
     }
   }, [])
 
-  const loadTopologyUnionFromApi = useCallback(async () => {
+  const loadNodeConnectionsFromApi = useCallback(async () => {
     try {
-      const nextTopology = await trackerApi.getTopologyUnion()
+      const nextTopology = await trackerApi.getNodeConnections()
 
       return nextTopology
     } catch (e) {
@@ -131,14 +131,14 @@ function useControllerContext() {
       if (streamId) {
         newTopology = await loadTopologyFromApi({ id: streamId })
       } else {
-        newTopology = await loadTopologyUnionFromApi()
+        newTopology = await loadNodeConnectionsFromApi()
       }
 
       if (!isMounted()) { return }
 
       setTopology(newTopology)
     })
-  ), [wrapTopology, loadTopologyFromApi, loadTopologyUnionFromApi, setTopology, isMounted])
+  ), [wrapTopology, loadTopologyFromApi, loadNodeConnectionsFromApi, setTopology, isMounted])
 
   const resetTopology = useCallback(() => {
     setTopology({})

--- a/src/contexts/Store.test.jsx
+++ b/src/contexts/Store.test.jsx
@@ -1,0 +1,281 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+import { Provider as StoreProvider, useStore } from './Store'
+
+let container
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  document.body.removeChild(container)
+  container = null
+})
+
+describe('Store', () => {
+  describe('nodes', () => {
+    it('returns nodes', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      act(() => {
+        store.addNodes([{
+          id: '1',
+          title: 'Node 1',
+        }, {
+          id: '2',
+          title: 'Node 2',
+        }, {
+          id: '3',
+          title: 'Node 3',
+        }])
+      })
+
+      expect(store.nodes).toStrictEqual([{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '2',
+        title: 'Node 2',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }])
+      expect(store.visibleNodes).toStrictEqual([])
+      expect(store.activeNode).toStrictEqual(undefined)
+    })
+
+    it('returns the active node', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      act(() => {
+        store.addNodes([{
+          id: '1',
+          title: 'Node 1',
+        }, {
+          id: '2',
+          title: 'Node 2',
+        }, {
+          id: '3',
+          title: 'Node 3',
+        }])
+      })
+
+      expect(store.activeNode).toStrictEqual(undefined)
+
+      act(() => {
+        store.setActiveNodeId('2')
+      })
+
+      expect(store.visibleNodes).toStrictEqual([])
+      expect(store.activeNode).toStrictEqual({
+        id: '2',
+        title: 'Node 2',
+      })
+    })
+
+    it('returns visible nodes when topology is set', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      act(() => {
+        store.addNodes([{
+          id: '1',
+          title: 'Node 1',
+        }, {
+          id: '2',
+          title: 'Node 2',
+        }, {
+          id: '3',
+          title: 'Node 3',
+        }, {
+          id: '4',
+          title: 'Node 4',
+        }])
+      })
+
+      expect(store.visibleNodes).toStrictEqual([])
+
+      act(() => {
+        store.setTopology({
+          '1': ['3', '4'],
+          '3': ['1'],
+          '4': ['1'],
+        })
+      })
+
+      expect(store.visibleNodes).toStrictEqual([{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }, {
+        id: '4',
+        title: 'Node 4',
+      }])
+      expect(store.activeNode).toStrictEqual(undefined)
+    })
+
+    it('returns active node when set with topology', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      act(() => {
+        store.addNodes([{
+          id: '1',
+          title: 'Node 1',
+        }, {
+          id: '2',
+          title: 'Node 2',
+        }, {
+          id: '3',
+          title: 'Node 3',
+        }, {
+          id: '4',
+          title: 'Node 4',
+        }])
+      })
+
+      expect(store.visibleNodes).toStrictEqual([])
+
+      act(() => {
+        store.setTopology({
+          '1': ['3', '4'],
+          '3': ['1'],
+          '4': ['1'],
+        }, '4')
+      })
+
+      expect(store.visibleNodes).toStrictEqual([{
+        id: '1',
+        title: 'Node 1',
+      }, {
+        id: '3',
+        title: 'Node 3',
+      }, {
+        id: '4',
+        title: 'Node 4',
+      }])
+      expect(store.activeNode).toStrictEqual({
+        id: '4',
+        title: 'Node 4',
+      })
+    })
+  })
+
+  describe('streams', () => {
+    it('returns active stream', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      expect(store.stream).toStrictEqual(undefined)
+
+      act(() => {
+        store.setStream({
+          id: '0x123/test/stream',
+          description: 'My test stream',
+        })
+      })
+
+      expect(store.stream).toStrictEqual({
+        id: '0x123/test/stream',
+        description: 'My test stream',
+      })
+    })
+
+    it('resets active stream', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      act(() => {
+        store.setStream({
+          id: '0x123/test/stream',
+          description: 'My test stream',
+        })
+      })
+
+      expect(store.stream).toStrictEqual({
+        id: '0x123/test/stream',
+        description: 'My test stream',
+      })
+
+      act(() => {
+        store.setStream(undefined)
+      })
+
+      expect(store.stream).toStrictEqual(undefined)
+    })
+  })
+})

--- a/src/utils/api/streamr.test.js
+++ b/src/utils/api/streamr.test.js
@@ -11,6 +11,155 @@ describe('streamr API', () => {
     request.get.mockClear()
   })
 
+  describe('searchStreams', () => {
+    it('does not search for specific stream if search is empty', async () => {
+      config.default.mockReturnValue({
+        streamr: {
+          http: '',
+        },
+      })
+
+      const getMock = jest.fn().mockResolvedValue(undefined)
+      request.get.mockImplementation(getMock)
+
+      const result = await all.searchStreams()
+
+      expect(getMock).toBeCalledWith({
+        url: '/streams',
+        options: {
+          params: {
+            public: true,
+            search: '',
+          },
+        },
+      })
+      expect(getMock).toBeCalledTimes(1)
+      expect(result).toStrictEqual([])
+    })
+
+    it('searches for specific stream and other results', async () => {
+      config.default.mockReturnValue({
+        streamr: {
+          http: '',
+        },
+      })
+
+      const getMock = jest.fn().mockResolvedValue(undefined)
+      request.get.mockImplementation(getMock)
+
+      const result = await all.searchStreams({
+        search: 'Helsinki',
+      })
+
+      expect(getMock).toBeCalledTimes(2)
+      expect(getMock).toBeCalledWith({
+        url: '/streams',
+        options: {
+          params: {
+            public: true,
+            search: 'helsinki',
+          },
+        },
+      })
+      expect(getMock).toBeCalledWith({
+        url: '/streams/Helsinki/validation',
+      })
+      expect(result).toStrictEqual([])
+    })
+
+    it('ignores if specific stream is not found', async () => {
+      config.default.mockReturnValue({
+        streamr: {
+          http: '',
+        },
+      })
+
+      const getMock = jest.fn(({ url }) => {
+        if (url === '/streams/Helsinki/validation') {
+          const error = new Error()
+          error.response = {
+            status: 404,
+          }
+          throw error
+        }
+
+        if (url === '/streams') {
+          return Promise.resolve([{
+            id: 'streamr.eth/trams',
+            description: 'Helsinki trams demo',
+          }])
+        }
+
+        throw new Error()
+      })
+      request.get.mockImplementation(getMock)
+
+      const result = await all.searchStreams({
+        search: 'Helsinki',
+      })
+
+      expect(getMock).toBeCalledTimes(2)
+      expect(result).toStrictEqual([{
+        type: 'streams',
+        id: 'streamr.eth/trams',
+        name: 'streamr.eth/trams',
+        description: 'Helsinki trams demo',
+      }])
+    })
+
+    it('places specific stream result first', async () => {
+      config.default.mockReturnValue({
+        streamr: {
+          http: '',
+        },
+      })
+
+      const getMock = jest.fn(({ url }) => {
+        if (url === '/streams/streamr.eth%2Ftrams/validation') {
+          return Promise.resolve({
+            id: 'streamr.eth/trams',
+            description: 'Helsinki trams demo',
+          })
+        }
+
+        if (url === '/streams') {
+          return Promise.resolve([{
+            id: '1',
+            description: 'streamr.eth/trams fake 1',
+          }, {
+            id: '2',
+            description: 'streamr.eth/trams fake 2',
+          }])
+        }
+
+        throw new Error()
+      })
+      request.get.mockImplementation(getMock)
+
+      const result = await all.searchStreams({
+        search: 'streamr.eth/trams',
+      })
+
+      expect(getMock).toBeCalledTimes(2)
+      expect(result).toStrictEqual([{
+        type: 'streams',
+        id: 'streamr.eth/trams',
+        name: 'streamr.eth/trams',
+        description: 'Helsinki trams demo',
+      }, {
+        type: 'streams',
+        id: '1',
+        name: '1',
+        description: 'streamr.eth/trams fake 1',
+      }, {
+        type: 'streams',
+        id: '2',
+        name: '2',
+        description: 'streamr.eth/trams fake 2',
+      }])
+    })
+  })
+
   describe('getStreams', () => {
     it('calls API with params', async () => {
       config.default.mockReturnValue({

--- a/src/utils/api/streamr.ts
+++ b/src/utils/api/streamr.ts
@@ -14,7 +14,7 @@ export type SearchResult = {
   description?: string,
 }
 
-export const searchStreams = async ({ search = '' }: SearchStreams): Promise<SearchResult[]> => {
+export const searchStreams = async ({ search = '' }: SearchStreams = {}): Promise<SearchResult[]> => {
   const params = {
     public: true,
     search: (search || '').trim().toLowerCase(),

--- a/src/utils/api/tracker.test.js
+++ b/src/utils/api/tracker.test.js
@@ -127,7 +127,7 @@ describe('tracker API', () => {
     })
   })
 
-  describe('getTopologyUnion', () => {
+  describe('getNodeConnections', () => {
     it('combines topologies from multiple trackers', async () => {
       const results = [{
         http: 'http://tracker1',
@@ -153,21 +153,21 @@ describe('tracker API', () => {
       })
 
       const getMock = jest.fn().mockImplementation(({ url }) => {
-        const { topology } = results.find(({ http }) => `${http}/topology-union/` === url)
+        const { topology } = results.find(({ http }) => `${http}/node-connections/` === url)
 
         return Promise.resolve(topology)
       })
 
       request.get.mockImplementation(getMock)
 
-      const result = await all.getTopologyUnion()
+      const result = await all.getNodeConnections()
 
       expect(getAllTrackersMock).toBeCalled()
       expect(getMock).toBeCalledWith({
-        url: 'http://tracker1/topology-union/',
+        url: 'http://tracker1/node-connections/',
       })
       expect(getMock).toBeCalledWith({
-        url: 'http://tracker2/topology-union/',
+        url: 'http://tracker2/node-connections/',
       })
       expect(result).toStrictEqual({
         'node1': ['node2', 'node4', 'node3'],

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -101,19 +101,19 @@ export const getTopology = async ({ id }: { id: string }): Promise<Topology> => 
   return topology || {}
 }
 
-export const getTopologyUnion = async (): Promise<Topology> => {
+export const getNodeConnections = async (): Promise<Topology> => {
   const trackerUrls = await getTrackers()
 
-  let topologyUnion
+  let nodeConnections
 
   try {
     const topologyPromises = trackerUrls.map((url) => get<Topology>({
-      url: `${url}/topology-union/`,
+      url: `${url}/node-connections/`,
     }))
 
     const topologies = await Promise.all(topologyPromises)
 
-    topologyUnion = (topologies || []).reduce((combined, topology) => {
+    nodeConnections = (topologies || []).reduce((combined, topology) => {
       const nextCombined = {
         ...combined,
       }
@@ -121,7 +121,7 @@ export const getTopologyUnion = async (): Promise<Topology> => {
       Object.keys(topology || {}).forEach((nodeId) => {
         if (nextCombined[nodeId]) {
           const connections = new Set([
-            ...(nextCombined[nodeId]),
+            ...nextCombined[nodeId],
             ...topology[nodeId],
           ])
 
@@ -135,8 +135,8 @@ export const getTopologyUnion = async (): Promise<Topology> => {
     }, {})
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.warn(`Failed to load topology union: ${e.message}`)
+    console.warn(`Failed to load node connections: ${e.message}`)
   }
 
-  return topologyUnion || {}
+  return nodeConnections || {}
 }


### PR DESCRIPTION
Loads topology in default view from all trackers, using the `/node-connections/` endpoint. This returns all the nodes and their connections.

You'll need to update your Docker env to latest for the endpoint to work.