### PR TITLE
[FRONT-197][FRONT-70] Add expansion of clusters that have overlapping nodes

### DIFF
--- a/src/components/Map/Map.stories.tsx
+++ b/src/components/Map/Map.stories.tsx
@@ -132,3 +132,36 @@ export const ZoomControls: Story = (args) => {
     />
   )
 }
+
+export const OverlappingNodes: Story = (args) => {
+  const [viewport, setViewport] = useState<ViewportProps>({
+    width: 800,
+    height: 600,
+    latitude: 60.16952,
+    longitude: 24.93545,
+    zoom: 2,
+    bearing: 0,
+    pitch: 0,
+    altitude: 0,
+    maxZoom: 20,
+    minZoom: 0,
+    maxPitch: 60,
+    minPitch: 0,
+  })
+
+  const overlappingNodes = nodes.flatMap((node, index) =>
+    [...Array(index * 3).keys()].flatMap((_, idx) => ({
+      ...node,
+      id: node.id + idx,
+    })),
+  )
+
+  return (
+    <Map
+      nodes={overlappingNodes}
+      topology={topology}
+      viewport={viewport}
+      setViewport={setViewport}
+    />
+  )
+}

--- a/src/components/Map/MarkerLayer.tsx
+++ b/src/components/Map/MarkerLayer.tsx
@@ -17,7 +17,7 @@ const arePointsOverlapped = (a: ClusterPointFeature, b: ClusterPointFeature) => 
 }
 
 const getCirclePositions = (center: [number, number], count: number) => {
-  const circleFootSeparation = 0.00003
+  const circleFootSeparation = 0.000018
   const circumference = circleFootSeparation * (2 + count)
   const legLength = circumference / (2 * Math.PI)
   const angleStep = (2 * Math.PI) / count

--- a/src/components/Map/MarkerLayer.tsx
+++ b/src/components/Map/MarkerLayer.tsx
@@ -22,7 +22,7 @@ const getCirclePositions = (center: [number, number], count: number) => {
   const legLength = circumference / (2 * Math.PI)
   const angleStep = (2 * Math.PI) / count
 
-  return [...Array(count).keys()].map((item, index) => {
+  return [...Array(count).keys()].map((_, index) => {
     const angle = index * angleStep
     return {
       latitude: center[1] + (legLength * Math.cos(angle)),

--- a/src/components/Map/MarkerLayer.tsx
+++ b/src/components/Map/MarkerLayer.tsx
@@ -12,6 +12,28 @@ type Props = {
   onNodeClick?: (v: string) => void,
 }
 
+const arePointsOverlapped = (a: ClusterPointFeature, b: ClusterPointFeature) => {
+  return a.geometry.coordinates.every((coord, index) => coord === b.geometry.coordinates[index])
+}
+
+const getCirclePositions = (center: [number, number], count: number) => {
+  const circleFootSeparation = 0.00003
+  const circumference = circleFootSeparation * (2 + count)
+  const legLength = circumference / (2 * Math.PI)
+  const angleStep = (2 * Math.PI) / count
+
+  return [...Array(count).keys()].map((item, index) => {
+    const angle = index * angleStep
+    return {
+      latitude: center[1] + (legLength * Math.cos(angle)),
+      longitude: center[0] + (legLength * Math.sin(angle)),
+      angle,
+      legLength,
+      index,
+    }
+  })
+}
+
 const MarkerLayer = ({
   supercluster,
   clusters,
@@ -23,19 +45,54 @@ const MarkerLayer = ({
   <>
     {clusters.map((cluster) => {
       const [longitude, latitude] = cluster.geometry.coordinates
-      const { cluster: isCluster, point_count: pointCount, nodeId } = cluster.properties
+      const {
+        cluster: isCluster,
+        point_count: pointCount,
+        nodeId,
+      } = cluster.properties
 
       if (isCluster) {
+        if (cluster.id == null ||
+          supercluster == null ||
+          typeof cluster.id !== 'number'
+        ) {
+          return null
+        }
+
+        // Check if we have overlapping markers
+        if (cluster.id && cluster) {
+          const child = supercluster.getChildren(cluster.id)
+
+          if (child.length > 1 && child.every((c) => arePointsOverlapped(c, child[0]))) {
+            const circle = getCirclePositions(
+              cluster.geometry.coordinates as [number, number],
+              child.length,
+            )
+
+            return child.map((point, index) => {
+              const id = point.properties.nodeId
+              const lat = circle[index].latitude
+              const lng = circle[index].longitude
+
+              return (
+                <Marker key={`expanded-cluster-${id}`} latitude={lat} longitude={lng}>
+                  <NodeMarker
+                    id={id}
+                    isActive={activeNode === id}
+                    onClick={() => onNodeClick && onNodeClick(id)}
+                  />
+                </Marker>
+              )
+            })
+          }
+        }
+
         return (
           <Marker key={`cluster-${cluster.id}`} latitude={latitude} longitude={longitude}>
             <ClusterMarker
               size={pointCount}
               onClick={() => {
-                if (
-                  cluster.id == null ||
-                  supercluster == null ||
-                  typeof cluster.id !== 'number'
-                ) {
+                if (typeof cluster.id !== 'number') {
                   return
                 }
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -10,6 +10,7 @@ import ReactMapGL, {
   ViewportProps,
   FlyToInterpolator,
   LinearInterpolator,
+  WebMercatorViewport,
 } from 'react-map-gl'
 import useSupercluster from 'use-supercluster'
 import { PointFeature } from 'supercluster'
@@ -66,6 +67,16 @@ const padBounds = (bounds: number[], padding: number) => {
   return bounds
 }
 
+const getBounds = (viewport: ViewportProps) => {
+  const vp = new WebMercatorViewport({
+    ...viewport,
+  })
+  const [north, west] = vp.unproject([0, 0])
+  const [east, south] = vp.unproject([viewport.width, viewport.height])
+  const bounds = [north, south, east, west]
+  return bounds
+}
+
 export const Map = ({
   nodes,
   topology,
@@ -104,12 +115,7 @@ export const Map = ({
     })), [nodes])
 
   // Calculate map bounds for current viewport
-  const vp = new WebMercatorViewport({
-    ...viewport,
-  })
-  const [north, west] = vp.unproject([0, 0])
-  const [east, south] = vp.unproject([viewport.width, viewport.height])
-  const bounds = [north, south, east, west]
+  const bounds = getBounds(viewport)
 
   // Calculate clusters
   const { clusters, supercluster } = useSupercluster({

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -54,6 +54,18 @@ const defaultViewport = {
   minPitch: 0,
 }
 
+const padBounds = (bounds: number[], padding: number) => {
+  if (bounds != null) {
+    return [
+      bounds[0] - padding,
+      bounds[1] - padding,
+      bounds[2] + padding,
+      bounds[3] + padding,
+    ]
+  }
+  return bounds
+}
+
 export const Map = ({
   nodes,
   topology,
@@ -76,42 +88,54 @@ export const Map = ({
     })
   ), [topology])
 
-  const points: Array<PointFeature<NodeProperties>> = (nodes || []).map((node) => ({
-    type: 'Feature',
-    properties: {
-      nodeId: node.id,
-      cluster: false,
-      point_count: 1,
-      point_count_abbreviated: '1',
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [node.longitude, node.latitude],
-    },
-  }))
-  let bounds = mapRef.current?.getMap()?.getBounds().toArray().flat() as [
-    number,
-    number,
-    number,
-    number
-  ]
-  const safeMargin = 0.1
-  // Add a bit of safe margin to bounds so that supercluster will not filter
-  // markers on the edges of viewport so aggressively.
-  if (bounds != null) {
-    bounds = [
-      bounds[0] - safeMargin,
-      bounds[1] - safeMargin,
-      bounds[2] + safeMargin,
-      bounds[3] + safeMargin,
-    ]
-  }
+  const points: Array<PointFeature<NodeProperties>> = useMemo(() =>
+    (nodes || []).map((node) => ({
+      type: 'Feature',
+      properties: {
+        nodeId: node.id,
+        cluster: false,
+        point_count: 1,
+        point_count_abbreviated: '1',
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [node.longitude, node.latitude],
+      },
+    })), [nodes])
+
+  // Calculate map bounds for current viewport
+  const vp = new WebMercatorViewport({
+    ...viewport,
+  })
+  const [north, west] = vp.unproject([0, 0])
+  const [east, south] = vp.unproject([viewport.width, viewport.height])
+  const bounds = [north, south, east, west]
+
+  // Calculate clusters
   const { clusters, supercluster } = useSupercluster({
     points,
-    bounds,
+    // Add a bit of safe margin to bounds so that supercluster will not filter
+    // markers on the edges of viewport so aggressively.
+    bounds: padBounds(bounds, 0.1) as [number, number, number, number],
     zoom: viewport.zoom,
     options: {
       radius: 40,
+      minZoom: viewport.minZoom,
+      maxZoom: viewport.maxZoom,
+    },
+  })
+
+  // Calculate clusters separately for the whole world at current zoom level
+  // so that we can use it to draw connections even when nodes are out of
+  // current viewport.
+  const worldBounds = [-180, -90, 180, 90] as [number, number, number, number]
+  const { clusters: worldClusters, supercluster: worldSupercluster } = useSupercluster({
+    points,
+    bounds: worldBounds,
+    zoom: viewport.zoom,
+    options: {
+      radius: 40,
+      minZoom: viewport.minZoom,
       maxZoom: viewport.maxZoom,
     },
   })
@@ -125,22 +149,22 @@ export const Map = ({
       ref={mapRef}
       onClick={onMapClick}
     >
+      {worldSupercluster != null && (
+        <ConnectionLayer
+          supercluster={worldSupercluster}
+          clusters={worldClusters}
+          nodeConnections={connections}
+        />
+      )}
       {supercluster != null && (
-        <>
-          <ConnectionLayer
-            supercluster={supercluster}
-            clusters={clusters}
-            nodeConnections={connections}
-          />
-          <MarkerLayer
-            supercluster={supercluster}
-            clusters={clusters}
-            viewport={viewport}
-            setViewport={(...args) => setViewport(...args)}
-            activeNode={activeNode && activeNode.id}
-            onNodeClick={onNodeClick}
-          />
-        </>
+        <MarkerLayer
+          supercluster={supercluster}
+          clusters={clusters}
+          viewport={viewport}
+          setViewport={(...args) => setViewport(...args)}
+          activeNode={activeNode && activeNode.id}
+          onNodeClick={onNodeClick}
+        />
       )}
       <NavigationControl
         onZoomIn={onZoomIn}
@@ -168,18 +192,7 @@ export const ConnectedMap = () => {
   } = useStore()
   const history = useHistory()
   const [viewport, setViewport] = useState<ViewportProps>({
-    width: 400,
-    height: 400,
-    latitude: 60.16952,
-    longitude: 24.93545,
-    zoom: 10,
-    bearing: 0,
-    pitch: 0,
-    altitude: 0,
-    maxZoom: 20,
-    minZoom: 0,
-    maxPitch: 60,
-    minPitch: 0,
+    ...defaultViewport,
     transitionInterpolator: new FlyToInterpolator({
       speed: 3,
     }),

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -10,7 +10,7 @@ export const getTrackers = async (): Promise<string[]> => {
   const trackerRegistry = await Utils.getTrackerRegistryFromContract(getConfig().tracker)
 
   const result: string[] = (trackerRegistry.getAllTrackers() || [])
-    .map(({ http }: { http: string }) => http.replace('10.200.10.1', '192.168.1.3'))
+    .map(({ http }: { http: string }) => http)
     .filter(Boolean)
 
   return result || []

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -10,7 +10,7 @@ export const getTrackers = async (): Promise<string[]> => {
   const trackerRegistry = await Utils.getTrackerRegistryFromContract(getConfig().tracker)
 
   const result: string[] = (trackerRegistry.getAllTrackers() || [])
-    .map(({ http }: { http: string }) => http)
+    .map(({ http }: { http: string }) => http.replace('10.200.10.1', '192.168.1.3'))
     .filter(Boolean)
 
   return result || []


### PR DESCRIPTION
Add feature for expanding clusters that have overlapping nodes inside:

![cluster](https://user-images.githubusercontent.com/432588/103640941-95de7580-4f59-11eb-8257-4f6504c8fcc4.gif)

@mattatgit: This probably needs a design pass? Should we add lines pointing to the center point?

Also fixes problem with node connection drawing that made the connections disappear if either of the connected nodes was out of viewport.

PS. I noticed that nodes seem not to form a perfect circle for some reason. Anyone can spot why x-axis looks like it's squashed a bit.