### PR TITLE
[FRONT-216] Network Explorer search results view improvements

### DIFF
--- a/src/components/Highlight/Hightlight.stories.tsx
+++ b/src/components/Highlight/Hightlight.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react/types-6-0'
+
+import Highlight from '.'
+
+export default {
+  title: 'Highlight',
+  component: Highlight,
+} as Meta
+
+const Template: Story<{
+  search: string,
+}> = ({ search }) => (
+  <Highlight search={search}>
+    The quick brown fox jumps over the lazy dog
+  </Highlight>
+)
+
+export const Basic = Template.bind({})
+Basic.args = {
+  search: 'brown',
+}

--- a/src/components/Highlight/index.tsx
+++ b/src/components/Highlight/index.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react'
+import escapeRegExp from 'lodash/escapeRegExp'
+
+type Props = {
+  children: React.ReactNode,
+  search?: string,
+}
+
+const Highlight = ({ search: originalSearch, children: text, ...props }: Props) => {
+  const displayText = useMemo(() => {
+    const search = (originalSearch || '').trim()
+
+    if (!search) {
+      return text
+    }
+
+    const regex = new RegExp(`(${escapeRegExp(search)})`, 'gi')
+    const parts = String(text).split(regex)
+
+    return parts.filter(Boolean).map((part, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      regex.test(part) ? <mark key={index}>{part}</mark> : part
+    ))
+  }, [originalSearch, text])
+
+  return displayText ? (<>{displayText}</>) : null
+}
+
+export default Highlight

--- a/src/components/SearchBox/Search.tsx
+++ b/src/components/SearchBox/Search.tsx
@@ -57,6 +57,7 @@ const Search = styled(ControlBox)`
     ${SearchResults} {
       max-height: 280px;
       overflow: scroll;
+      padding: 8px 0;
     }
   }
 `

--- a/src/components/SearchBox/SearchBox.stories.tsx
+++ b/src/components/SearchBox/SearchBox.stories.tsx
@@ -42,6 +42,10 @@ const results: Array<SearchResult> = [{
   type: 'nodes',
   name: 'Warm Fiery Octagon',
   description: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',
+}, {
+  id: '4',
+  type: 'streams',
+  name: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/test/long-path',
 }]
 
 export const Basic = () => {
@@ -120,7 +124,10 @@ export const WithResults = () => {
           onChange={setSearch}
           onClear={() => setSearch('')}
         />
-        <Search.Results results={results} />
+        <Search.Results
+          results={results}
+          highlight={search}
+        />
       </Search>
     </Wrapper>
   )

--- a/src/components/SearchBox/SearchResults.tsx
+++ b/src/components/SearchBox/SearchResults.tsx
@@ -24,25 +24,31 @@ const Icon = styled.div`
     left: 50%;
     transform: translate(-50%, -50%);
   }
+
+  @media (min-width: ${SM}px) {
+    width: 24px;
+    height: 24px;
+  }
 `
 
 const Row = styled.div`
   display: grid;
   grid-template-columns: 64px 1fr;
   height: 64px;
-  font-size: 12px;
-  line-height: 16px;
   cursor: pointer;
   color: #CDCDCD;
   background-color: #FFFFFF;
   font-family: ${SANS};
-  font-size: 12px;
+
+  ${Icon} {
+    background-color: #F5F5F5;
+  }
 
   &:hover {
-    background-color: #F8F8F8;
+    background-color: #F5F5F5;
 
     ${Icon} {
-      background-color: transparent;
+      background-color: #EFEFEF;
     }
   }
 
@@ -50,8 +56,9 @@ const Row = styled.div`
     background-color: #F5F5F5;
   }
 
-  @media (min-width: ${MD}px) {
-    font-size: 14px;
+  @media (min-width: ${SM}px) {
+    grid-template-columns: 48px 1fr;
+    height: 40px;
   }
 `
 
@@ -62,26 +69,27 @@ const Item = styled.div`
   padding-right: 12px;
   white-space: nowrap;
 
-  span:first-child {
+  > span:first-child {
     color: #323232;
     font-weight: 500;
+    font-size: 12px;
   }
 
-  span {
+  > span:last-child {
+    font-weight: 500;
+    font-size: 10px;
+  }
+
+  > span {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    display: block;
   }
 
-  @media (max-width: ${SM}px) {
-    span {
-      display: block;
-    }
-  }
-
-  @media (min-width: ${SM}px) {
-    span + span {
-      margin-left: 8px;
+  @media (max-width: ${MD}px) {
+    > span:first-child {
+      margin-bottom: 2px;
     }
   }
 `
@@ -122,6 +130,12 @@ const ResultIcon = ({ type }: ResultIconProps) => {
   }
 }
 
+const resultTypes = {
+  'streams': 'Stream',
+  'locations': 'Place',
+  'nodes': 'Node',
+}
+
 const UnstyledSearchResults = ({ results, onClick, ...props }: Props) => (
   <div {...props}>
     <List>
@@ -134,7 +148,7 @@ const UnstyledSearchResults = ({ results, onClick, ...props }: Props) => (
           </IconWrapper>
           <Item>
             <span>{truncate(result.name)}</span>
-            <span>{result.description}</span>
+            <span>{resultTypes[result.type] || ('')}</span>
           </Item>
         </Row>
       ))}
@@ -151,10 +165,6 @@ const SearchResults = styled(UnstyledSearchResults)`
     ${Row} {
       border: 1px solid #EFEFEF;
       border-radius: 4px;
-    }
-
-    ${Icon} {
-      background-color: #F5F5F5;
     }
   }
 

--- a/src/components/SearchBox/SearchResults.tsx
+++ b/src/components/SearchBox/SearchResults.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components/macro'
 
 import { StreamIcon, NodeIcon, LocationIcon } from './Icons'
+import Highlight from '../Highlight'
+
 import { SearchResult } from '../../utils/api/streamr'
 import { SM, MD, SANS } from '../../utils/styled'
 import { truncate } from '../../utils/text'
@@ -69,26 +71,31 @@ const Item = styled.div`
   padding-right: 12px;
   white-space: nowrap;
 
-  > span:first-child {
+  > div:first-child {
     color: #323232;
     font-weight: 500;
     font-size: 12px;
   }
 
-  > span:last-child {
+  > div:last-child {
     font-weight: 500;
     font-size: 10px;
   }
 
-  > span {
+  > div {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     display: block;
   }
 
+  mark {
+    background-color: transparent;
+    font-weight: 700;
+  }
+
   @media (max-width: ${MD}px) {
-    > span:first-child {
+    > div:first-child {
       margin-bottom: 2px;
     }
   }
@@ -108,6 +115,7 @@ const List = styled.div`
 type Props = {
   results: Array<SearchResult>,
   onClick?: (result: SearchResult) => void,
+  highlight?: string,
 }
 
 type ResultIconProps = {
@@ -136,7 +144,12 @@ const resultTypes = {
   'nodes': 'Node',
 }
 
-const UnstyledSearchResults = ({ results, onClick, ...props }: Props) => (
+const UnstyledSearchResults = ({
+  results,
+  onClick,
+  highlight,
+  ...props
+}: Props) => (
   <div {...props}>
     <List>
       {results.map((result) => (
@@ -147,8 +160,12 @@ const UnstyledSearchResults = ({ results, onClick, ...props }: Props) => (
             </Icon>
           </IconWrapper>
           <Item>
-            <span>{truncate(result.name)}</span>
-            <span>{resultTypes[result.type] || ('')}</span>
+            <div>
+              <Highlight search={highlight && truncate(highlight)}>
+                {truncate(result.name)}
+              </Highlight>
+            </div>
+            <div>{resultTypes[result.type] || ('')}</div>
           </Item>
         </Row>
       ))}

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -128,6 +128,7 @@ const SearchBox = () => {
         <Search.Results
           results={searchResults}
           onClick={onResultClick}
+          highlight={search}
         />
       )}
     </Search>


### PR DESCRIPTION
> Give the icons a background box
> 
> Each search result needs a 2 line layout. 1st line is search result name, 2nd is stream ID (or path) or category such as "Place" etc
> 
> Use 8pts of padding between top & bottom edge of each section

Tweak result list UI in desktop, add highlighting of search term:

<img width="389" alt="Screenshot 2021-01-18 at 16 02 54" src="https://user-images.githubusercontent.com/1064982/104924902-c33e1100-59a6-11eb-9204-1079b0b9075b.png">

<img width="525" alt="Screenshot 2021-01-18 at 16 03 14" src="https://user-images.githubusercontent.com/1064982/104924905-c46f3e00-59a6-11eb-8794-0db8b3aa2fa9.png">
