### PR TITLE
[FRONT-217] Show only active node in default view, unload stream on search clear

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,27 +32,15 @@ function useUpdateSearchTextEffect() {
   const {
     updateSearch: updateSearchText,
     resetSearchResults,
-    streamId,
-    activeNode,
   } = useStore()
   const { pathname } = useLocation()
 
   useEffect(() => {
-    updateSearchText('')
-    resetSearchResults()
-  }, [updateSearchText, resetSearchResults, pathname])
-
-  const activeNodeTitle = activeNode && activeNode.title
-
-  useEffect(() => {
-    if (streamId) {
-      updateSearchText(streamId)
-    } else if (activeNodeTitle) {
-      updateSearchText(activeNodeTitle)
-    } else {
+    if (pathname === '/') {
       updateSearchText('')
+      resetSearchResults()
     }
-  }, [updateSearchText, streamId, activeNodeTitle])
+  }, [updateSearchText, resetSearchResults, pathname])
 }
 
 const TrackerLoader = () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,7 +3,6 @@ import {
   BrowserRouter,
   Route,
   Switch,
-  useLocation,
 } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -16,7 +15,7 @@ import UnstyledLoadingIndicator from '../components/LoadingIndicator'
 import Layout from '../components/Layout'
 import ErrorBoundary from '../components/ErrorBoundary'
 
-import { Provider as StoreProvider, useStore } from '../contexts/Store'
+import { Provider as StoreProvider } from '../contexts/Store'
 import { Provider as ControllerProvider, useController } from '../contexts/Controller'
 import { Provider as Pendingrovider, usePending } from '../contexts/Pending'
 
@@ -28,28 +27,8 @@ function useLoadTrackersEffect() {
   }, [loadTrackers])
 }
 
-function useUpdateSearchTextEffect() {
-  const {
-    updateSearch: updateSearchText,
-    resetSearchResults,
-  } = useStore()
-  const { pathname } = useLocation()
-
-  useEffect(() => {
-    if (pathname === '/') {
-      updateSearchText('')
-      resetSearchResults()
-    }
-  }, [updateSearchText, resetSearchResults, pathname])
-}
-
 const TrackerLoader = () => {
   useLoadTrackersEffect()
-  return null
-}
-
-const SearchTextUpdater = () => {
-  useUpdateSearchTextEffect()
   return null
 }
 
@@ -82,7 +61,6 @@ const App = () => (
           <Layout>
             <ErrorBoundary>
               <TrackerLoader />
-              <SearchTextUpdater />
               <Debug />
               <SearchBox />
               <Switch>

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -192,18 +192,6 @@ export const ConnectedMap = () => {
     250,
   )
 
-  // zoom selected network node into view
-  useEffect(() => {
-    if (activeNode) {
-      debouncedSetViewport((prev: ViewportProps) => ({
-        ...prev,
-        longitude: activeNode.longitude,
-        latitude: activeNode.latitude,
-        zoom: 10,
-      }))
-    }
-  }, [debouncedSetViewport, activeNode])
-
   // zoom selected location into view
   useEffect(() => {
     if (activeLocation) {
@@ -218,7 +206,7 @@ export const ConnectedMap = () => {
 
   // zoom topology into view
   useEffect(() => {
-    if (visibleNodes.length <= 0 || !!activeNode) { return }
+    if (visibleNodes.length <= 0) { return }
 
     debouncedSetViewport((prev: ViewportProps) => {
       const pointsLong = visibleNodes.map(point => point.longitude)
@@ -242,7 +230,7 @@ export const ConnectedMap = () => {
         zoom,
       }
     })
-  }, [debouncedSetViewport, visibleNodes, activeNode])
+  }, [debouncedSetViewport, visibleNodes])
 
   const windowSize = useWindowSize()
 
@@ -254,8 +242,6 @@ export const ConnectedMap = () => {
     }))
   }, [debouncedSetViewport, windowSize.width, windowSize.height])
 
-  const { id: activeNodeId } = activeNode || {}
-
   const onNodeClick = useCallback((nodeId: string) => {
     let path = '/'
 
@@ -263,12 +249,10 @@ export const ConnectedMap = () => {
       path += `streams/${encodeURIComponent(streamId)}/`
     }
 
-    if (nodeId !== activeNodeId) {
-      path += `nodes/${nodeId}`
-    }
+    path += `nodes/${nodeId}`
 
     history.replace(path)
-  }, [streamId, activeNodeId, history])
+  }, [streamId, history])
 
   // reset search view when clicking on map
   const onMapClick = useCallback(() => {

--- a/src/components/Node/TopologyList.tsx
+++ b/src/components/Node/TopologyList.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback } from 'react'
-import { useHistory } from 'react-router-dom'
+import React, { useMemo } from 'react'
 
 import { useStore } from '../../contexts/Store'
 import NodeList from '../NodeList'
@@ -9,38 +8,15 @@ type Props = {
 }
 
 const TopologyList = ({ id }: Props) => {
-  const { nodes, env } = useStore()
+  const { nodes } = useStore()
 
-  const history = useHistory()
-
-  const onNodeClick = useCallback((nodeId) => {
-    let path = '/'
-
-    if (id !== nodeId) {
-      path += `nodes/${nodeId}`
-    }
-
-    history.replace(path)
-  }, [id, history])
+  const currentNode = useMemo(() => nodes.find(({ id: nodeId }) => nodeId === id), [nodes, id])
 
   return (
     <NodeList
-      nodes={nodes}
+      nodes={currentNode ? [currentNode] : []}
       activeNodeId={id}
-      onNodeClick={onNodeClick}
-    >
-      <NodeList.Header>
-        Showing all
-        {' '}
-        <strong>{nodes.length}</strong>
-        {' '}
-        nodes in the
-        {' '}
-        <strong>{env && env.toUpperCase()}</strong>
-        {' '}
-        network
-      </NodeList.Header>
-    </NodeList>
+    />
   )
 }
 

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -47,7 +47,9 @@ export default () => {
     <>
       <NodeConnectionsLoader />
       <ActiveNodeSetter id={nodeId} />
-      <TopologyList id={nodeId} />
+      {!!nodeId && (
+        <TopologyList id={nodeId} />
+      )}
     </>
   )
 }

--- a/src/components/NodeList/NodeList.stories.tsx
+++ b/src/components/NodeList/NodeList.stories.tsx
@@ -10,28 +10,28 @@ export default {
 
 const nodes = [
   {
-    id: '1',
-    title: 'Node 1',
+    id: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',
+    title: 'Quick Green Aadvaark',
     latitude: 60.16952,
     longitude: 24.93545,
     placeName: 'Helsinki',
   }, {
-    id: '2',
-    title: 'Node 2',
+    id: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
+    title: 'Warm Fiery Octagon',
     latitude: 60.14952,
     longitude: 24.92545,
     placeName: 'Helsinki',
   },
   {
-    id: '3',
-    title: 'Node 3',
+    id: '0xFeaDE0B77130F5468D57037e2a259295bfdD8390',
+    title: 'Gold Spicy Fieldmouse',
     latitude: 52.51667,
     longitude: 13.38333,
     placeName: 'Berlin',
   },
   {
-    id: '4',
-    title: 'Node 4',
+    id: '0x538a2Fa87E03B280e10C83AA8dD7E5B15B868BD9',
+    title: 'Curved Slick Diamond',
     latitude: 47.49833,
     longitude: 19.04083,
     placeName: 'Budapest',
@@ -45,7 +45,7 @@ export const Basic = () => {
     <NodeList
       nodes={nodes}
       activeNodeId={activeNode}
-      onNodeClick={setActiveNode}
+      onNodeClick={(next) => setActiveNode((prev) => prev !== next ? next : undefined)}
     />
   )
 }

--- a/src/components/NodeList/NodeListItem.tsx
+++ b/src/components/NodeList/NodeListItem.tsx
@@ -1,8 +1,9 @@
 import React, { MouseEvent } from 'react'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import Identicon from 'react-identicons'
 
 import { MONO, MEDIUM } from '../../utils/styled'
+import { truncate } from '../../utils/text'
 import Stats from '../Stats'
 
 const Name = styled.div`
@@ -17,6 +18,13 @@ const Name = styled.div`
   }
 `
 
+const TitleRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 16px;
+`
+
 const NodeElement = styled.div`
   background: #FFFFFF;
   border: 1px solid #F5F5F5;
@@ -29,18 +37,16 @@ const NodeElement = styled.div`
   ${Name} {
     margin-left: 20px;
   }
-`
 
-const TitleRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 16px;
-  cursor: pointer;
+  ${({ theme }) => !!theme.clickable && css`
+    ${TitleRow} {
+      cursor: pointer;
 
-  :hover {
-    background: #F8F8F8;
-  }
+      :hover {
+        background: #F8F8F8;
+      }
+    }
+  `}
 `
 
 const PlaceName = styled.div`
@@ -66,6 +72,7 @@ type Props = {
   placeName: string,
   active: boolean,
   onClick: (event: MouseEvent<HTMLInputElement>) => void,
+  clickable?: boolean,
 }
 
 const NodeListItem = ({
@@ -74,8 +81,10 @@ const NodeListItem = ({
   placeName,
   active,
   onClick,
+  clickable,
+  ...props
 }: Props) => (
-  <NodeElement>
+  <NodeElement {...props} theme={{ clickable }}>
     <TitleRow onClick={onClick}>
       <Identicon
         string={nodeId}
@@ -87,7 +96,7 @@ const NodeListItem = ({
           <PlaceName>{placeName}</PlaceName>
         )}
         {!!active && (
-          <Address>{nodeId}</Address>
+          <Address title={nodeId}>{truncate(nodeId)}</Address>
         )}
       </Name>
     </TitleRow>

--- a/src/components/NodeList/index.tsx
+++ b/src/components/NodeList/index.tsx
@@ -43,7 +43,7 @@ const NodeList = ({
   children,
 }: Props) => {
   const onNodeClick = useCallback((nodeId: string) => {
-    if (onNodeClickProp) {
+    if (typeof onNodeClickProp === 'function') {
       onNodeClickProp(nodeId)
     }
   }, [onNodeClickProp])
@@ -59,6 +59,7 @@ const NodeList = ({
             title={title}
             placeName={placeName}
             active={activeNodeId === nodeId}
+            clickable={typeof onNodeClickProp === 'function'}
             onClick={() => onNodeClick(nodeId)}
           />
         ))}

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -50,9 +50,8 @@ const SearchBox = () => {
   const isDisabled = hasStream && !!isStreamLoading
 
   const onClear = useCallback(() => {
-    updateSearchText('')
-    resetSearchResults()
-  }, [updateSearchText, resetSearchResults])
+    history.push('/')
+  }, [history])
 
   const onSearch = useCallback((value: string) => {
     updateSearch({ search: value })
@@ -69,10 +68,14 @@ const SearchBox = () => {
   const onResultClick = useCallback(({ id, type }) => {
     switch (type) {
       case 'streams':
+        updateSearchText(id)
+        resetSearchResults()
         history.push(`/streams/${encodeURIComponent(id)}`)
         break
 
       case 'nodes':
+        updateSearchText('')
+        resetSearchResults()
         history.push(`/nodes/${id}`)
         break
 
@@ -83,7 +86,7 @@ const SearchBox = () => {
       default:
         break
     }
-  }, [history, setActiveLocationId])
+  }, [history, setActiveLocationId, updateSearchText, resetSearchResults])
 
   return (
     <Search

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -50,8 +50,10 @@ const SearchBox = () => {
   const isDisabled = hasStream && !!isStreamLoading
 
   const onClear = useCallback(() => {
+    updateSearchText('')
+    resetSearchResults()
     history.push('/')
-  }, [history])
+  }, [history, updateSearchText, resetSearchResults])
 
   const onSearch = useCallback((value: string) => {
     updateSearch({ search: value })

--- a/src/contexts/Store.test.jsx
+++ b/src/contexts/Store.test.jsx
@@ -154,63 +154,6 @@ describe('Store', () => {
       }])
       expect(store.activeNode).toStrictEqual(undefined)
     })
-
-    it('returns active node when set with topology', () => {
-      let store
-
-      function Test() {
-        store = useStore()
-
-        return null
-      }
-
-      render((
-        <StoreProvider>
-          <Test />
-        </StoreProvider>
-      ), container)
-
-      act(() => {
-        store.addNodes([{
-          id: '1',
-          title: 'Node 1',
-        }, {
-          id: '2',
-          title: 'Node 2',
-        }, {
-          id: '3',
-          title: 'Node 3',
-        }, {
-          id: '4',
-          title: 'Node 4',
-        }])
-      })
-
-      expect(store.visibleNodes).toStrictEqual([])
-
-      act(() => {
-        store.setTopology({
-          '1': ['3', '4'],
-          '3': ['1'],
-          '4': ['1'],
-        }, '4')
-      })
-
-      expect(store.visibleNodes).toStrictEqual([{
-        id: '1',
-        title: 'Node 1',
-      }, {
-        id: '3',
-        title: 'Node 3',
-      }, {
-        id: '4',
-        title: 'Node 4',
-      }])
-      expect(store.activeNode).toStrictEqual({
-        id: '4',
-        title: 'Node 4',
-      })
-    })
   })
 
   describe('streams', () => {


### PR DESCRIPTION
Fix:
> Node eth addresses are not following standard centre-truncation rules
>
> streams cannot be unloaded by clearing the search

- unload stream when clearing search
- When searching for node, node title is not shown in search
- Show only the active node in default view
- Don't zoom to active node anymore