### PR TITLE
[FRONT-224] Update node styling

### DIFF
--- a/src/components/Map/Markers.tsx
+++ b/src/components/Map/Markers.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import Identicon from 'react-identicons'
 
 import { SANS } from '../../utils/styled'
 
-// eslint-disable-next-line react/require-default-props,react/no-unused-prop-types
-const NodeIconSvg = ({ className }: { className?: string, active?: boolean }) => (
+const NodeIconSvg = ({ className }: { className?: string }) => (
   <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
     <path
       d="M16 0C27.8241 0 32 4.19557 32 16C32 27.7598 27.7545 32 16 32C4.28014 32 0 27.7054 0 16C0 4.24975 4.21033 0 16 0Z"
@@ -14,13 +13,14 @@ const NodeIconSvg = ({ className }: { className?: string, active?: boolean }) =>
 )
 
 const NodeIcon = styled(NodeIconSvg)`
-  fill: ${({ active }) => active ? 'white' : '#0324FF'};
+  fill: white;
+  overflow: visible; // need this to render stroke without clipping
 `
 
 const ClusterContainer = styled.div`
   position: relative;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   cursor: pointer;
   transform: translate(-50%, -50%);
   font-family: ${SANS};
@@ -28,12 +28,12 @@ const ClusterContainer = styled.div`
   font-size: 10px;
   line-height: 24px;
 
-  & span {
+  span {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    color: #ffffff;
+    color: #0324FF;
   }
 `
 
@@ -44,19 +44,34 @@ export const ClusterMarker = ({ size, onClick }: { size: number, onClick: () => 
   </ClusterContainer>
 )
 
-const NodeMarkerContainer = styled.div`
+type NodeMarkerContainerProps = {
+  active: boolean,
+}
+
+const NodeMarkerContainer = styled.div<NodeMarkerContainerProps>`
   position: relative;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   transform: translate(-50%, -50%);
   cursor: pointer;
+  transition: all 100ms ease-in-out;
 
-  & span {
+  canvas {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -40%);
+    transform: translate(-50%, -50%);
   }
+
+  ${({ active }) => !!active && css`
+    width: 32px;
+    height: 32px;
+
+    path {
+      stroke: #0324FF;
+      stroke-width: 1px;
+    }
+  `}
 `
 
 type NodeMarkerProps = {
@@ -66,15 +81,11 @@ type NodeMarkerProps = {
 }
 
 export const NodeMarker = ({ id, isActive, onClick }: NodeMarkerProps) => (
-  <NodeMarkerContainer onClick={onClick}>
-    <NodeIcon active={!!isActive} />
-    {!!isActive && (
-      <span>
-        <Identicon
-          string={id}
-          size={16}
-        />
-      </span>
-    )}
+  <NodeMarkerContainer onClick={onClick} active={!!isActive}>
+    <NodeIcon />
+    <Identicon
+      string={id}
+      size={14}
+    />
   </NodeMarkerContainer>
 )


### PR DESCRIPTION
Nodes (and clusters) are now 24px (down from 32px) in size. Identicon is shown at all times for nodes and when a node is selected, it will grow to 32px and gain a blue border.

![node](https://user-images.githubusercontent.com/432588/105158191-619cb480-5b16-11eb-93be-3e5dc492f5ea.gif)
