### PR TITLE
Move store from NavigationControl to parent component

### DIFF
--- a/src/components/Map/Map.stories.tsx
+++ b/src/components/Map/Map.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { Story, Meta } from '@storybook/react/types-6-0'
 import { ViewportProps } from 'react-map-gl'
+
 import { Map } from '.'
 import { Node } from '../../utils/api/tracker'
 
@@ -48,21 +49,23 @@ const topology = {
   '3': ['1', '4'],
 }
 
+const initialViewport = {
+  width: 800,
+  height: 600,
+  latitude: 60.16952,
+  longitude: 24.93545,
+  zoom: 2,
+  bearing: 0,
+  pitch: 0,
+  altitude: 0,
+  maxZoom: 20,
+  minZoom: 0,
+  maxPitch: 60,
+  minPitch: 0,
+}
+
 export const Nodes: Story = (args) => {
-  const [viewport, setViewport] = useState<ViewportProps>({
-    width: 800,
-    height: 600,
-    latitude: 60.16952,
-    longitude: 24.93545,
-    zoom: 2,
-    bearing: 0,
-    pitch: 0,
-    altitude: 0,
-    maxZoom: 20,
-    minZoom: 0,
-    maxPitch: 60,
-    minPitch: 0,
-  })
+  const [viewport, setViewport] = useState<ViewportProps>(initialViewport)
 
   return (
     <Map
@@ -75,20 +78,7 @@ export const Nodes: Story = (args) => {
 }
 
 export const ActiveNode: Story = (args) => {
-  const [viewport, setViewport] = useState<ViewportProps>({
-    width: 800,
-    height: 600,
-    latitude: 60.16952,
-    longitude: 24.93545,
-    zoom: 2,
-    bearing: 0,
-    pitch: 0,
-    altitude: 0,
-    maxZoom: 20,
-    minZoom: 0,
-    maxPitch: 60,
-    minPitch: 0,
-  })
+  const [viewport, setViewport] = useState<ViewportProps>(initialViewport)
   const [activeNode, setActiveNode] = useState<Node | undefined>(undefined)
 
   const onNodeClick = useCallback((activeId: string) => {
@@ -103,6 +93,42 @@ export const ActiveNode: Story = (args) => {
       setViewport={setViewport}
       activeNode={activeNode}
       onNodeClick={onNodeClick}
+    />
+  )
+}
+
+export const ZoomControls: Story = (args) => {
+  const [viewport, setViewport] = useState<ViewportProps>(initialViewport)
+
+  const onZoomIn = useCallback(() => {
+    setViewport((prev) => ({
+      ...prev,
+      zoom: prev.zoom + 1,
+    }))
+  }, [setViewport])
+
+  const onZoomOut = useCallback(() => {
+    setViewport((prev) => ({
+      ...prev,
+      zoom: prev.zoom - 1,
+    }))
+  }, [setViewport])
+
+  const onZoomReset = useCallback(() => {
+    setViewport((prev) => ({
+      ...initialViewport,
+    }))
+  }, [setViewport])
+
+  return (
+    <Map
+      nodes={nodes}
+      topology={topology}
+      viewport={viewport}
+      setViewport={setViewport}
+      onZoomIn={onZoomIn}
+      onZoomOut={onZoomOut}
+      onZoomReset={onZoomReset}
     />
   )
 }

--- a/src/components/Map/NavigationControl.tsx
+++ b/src/components/Map/NavigationControl.tsx
@@ -1,21 +1,5 @@
-import React, { useCallback, useMemo } from 'react'
-import { LinearInterpolator, ViewportProps } from 'react-map-gl'
+import React from 'react'
 import styled from 'styled-components/macro'
-
-import { useStore } from '../../contexts/Store'
-import useKeyDown from '../../hooks/useKeyDown'
-import { getCenteredViewport } from './utils'
-
-const Container = styled.div`
-  position: absolute;
-  right: 32px;
-  bottom: 32px;
-  display: flex;
-  flex-direction: column;
-  background: #FFFFFF;
-  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.08);
-  border-radius: 4px;
-`
 
 const Button = styled.button`
   width: 40px;
@@ -26,20 +10,25 @@ const Button = styled.button`
   font: inherit;
   color: inherit;
   background: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-  &:not(:last-child) {
-    border-bottom: 1px solid #EFEFEF;
+  svg {
+    width: 14px;
+    height: 14px;
   }
 `
 
-const LINEAR_TRANSITION_PROPS = {
-  transitionDuration: 300,
-  transitionEasing: (t: number) => t,
-  transitionInterpolator: new LinearInterpolator(),
-}
+const ResetButton = styled(Button)`
+  svg {
+    width: 18px;
+    height: 16px;
+  }
+`
 
 const RefreshIcon = () => (
-  <svg width="18" height="16" viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M13.2413 4.66639C12.5205 3.79333 11.5479 3.16398 10.4562 2.86423C9.3644 2.56449 8.20675 2.60897 7.14122 2.99159C6.07569 3.37421 5.15419 4.07633 4.50251 5.00212C3.85084 5.9279 3.50074 7.03224 3.5 8.16439V9.66639" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     <path d="M5 11.939C5.75586 12.74 6.73476 13.2955 7.80995 13.5338C8.88514 13.7721 10.0071 13.6821 11.0306 13.2756C12.0541 12.869 12.9319 12.1645 13.5505 11.2533C14.169 10.3422 14.4998 9.26632 14.5 8.16504V7.16504" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     <path d="M1.5 7.66504L3.5 9.66504L5.5 7.66504" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
@@ -48,64 +37,59 @@ const RefreshIcon = () => (
 )
 
 const MinusIcon = () => (
-  <svg width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M27 20H13" stroke="#323232" strokeWidth="2" />
+  <svg viewBox="0 0 14 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M14 1L0 0.999999" stroke="#323232" strokeWidth="2" />
   </svg>
 )
 
 const PlusIcon = () => (
-  <svg width="14" height="14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path stroke="#323232" strokeWidth="2" d="M7 0v14M14 7H0" />
   </svg>
 )
 
-type Props = {
-  setViewport: React.Dispatch<React.SetStateAction<ViewportProps>>,
+export type Props = {
+  onZoomIn?: () => void,
+  onZoomOut?: () => void,
+  onZoomReset?: () => void,
 }
 
-const NavigationControl = ({ setViewport }: Props) => {
-  const { visibleNodes } = useStore()
+const UnstyledNavigationControl = ({
+  onZoomIn,
+  onZoomOut,
+  onZoomReset,
+  ...props
+}: Props) => (
+  <div {...props}>
+    {typeof onZoomReset === 'function' && (
+      <ResetButton type="button" onClick={() => onZoomReset()}><RefreshIcon /></ResetButton>
+    )}
+    {typeof onZoomIn === 'function' && (
+      <Button type="button" onClick={() => onZoomIn()}><PlusIcon /></Button>
+    )}
+    {typeof onZoomOut === 'function' && (
+      <Button type="button" onClick={() => onZoomOut()}><MinusIcon /></Button>
+    )}
+  </div>
+)
 
-  const zoomIn = useCallback(() => {
-    setViewport((prev) => ({
-      ...prev,
-      zoom: prev.zoom + 1,
-      LINEAR_TRANSITION_PROPS,
-    }))
-  }, [setViewport])
+const NavigationControl = styled(UnstyledNavigationControl)`
+  position: absolute;
+  right: 32px;
+  bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  background: #FFFFFF;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
 
-  const zoomOut = useCallback(() => {
-    setViewport((prev) => ({
-      ...prev,
-      zoom: prev.zoom - 1,
-      LINEAR_TRANSITION_PROPS,
-    }))
-  }, [setViewport])
+  ${Button}:not(:last-child) {
+    border-bottom: 1px solid #EFEFEF;
+  }
 
-  const reset = useCallback(() => {
-    setViewport((prev) => {
-      const viewport = getCenteredViewport(visibleNodes, prev.width, prev.height)
-      return {
-        ...prev,
-        ...viewport,
-        LINEAR_TRANSITION_PROPS,
-      }
-    })
-  }, [setViewport, visibleNodes])
-
-  useKeyDown(useMemo(() => ({
-    '0': () => {
-      reset()
-    },
-  }), [reset]))
-
-  return (
-    <Container>
-      <Button onClick={reset}><RefreshIcon /></Button>
-      <Button onClick={zoomIn}><PlusIcon /></Button>
-      <Button onClick={zoomOut}><MinusIcon /></Button>
-    </Container>
-  )
-}
+  :empty {
+    display: none;
+  }
+`
 
 export default NavigationControl

--- a/src/components/SearchBox/Search.tsx
+++ b/src/components/SearchBox/Search.tsx
@@ -50,13 +50,15 @@ const Search = styled(ControlBox)`
 
   ${SearchResults} {
     max-height: calc(100vh - 120px);
-    overflow: scroll;
+    overflow: hidden;
+    overflow-y: scroll;
   }
 
   @media (min-width: ${SM}px) {
     ${SearchResults} {
       max-height: 280px;
-      overflow: scroll;
+      overflow: hidden;
+      overflow-y: scroll;
       padding: 8px 0;
     }
   }


### PR DESCRIPTION
Fixes broken `Map` storybook story, I moved the `useStore` hook out from `NavigationControl` into the connected parent component so the Map component can stay "dumb".