### PR TITLE
[FRONT-236] Set stream name to search field when loading a stream

### DIFF
--- a/src/components/Stream/index.tsx
+++ b/src/components/Stream/index.tsx
@@ -12,8 +12,10 @@ type StreamProps = {
 
 const TopologyLoader = ({ id }: StreamProps) => {
   const { loadTopology, resetTopology } = useController()
+  const { updateSearch } = useStore()
 
   useEffect(() => {
+    updateSearch(id)
     loadTopology({
       streamId: id,
     })
@@ -21,7 +23,7 @@ const TopologyLoader = ({ id }: StreamProps) => {
     return () => {
       resetTopology()
     }
-  }, [loadTopology, resetTopology, id])
+  }, [loadTopology, resetTopology, updateSearch, id])
 
   return null
 }


### PR DESCRIPTION
Stream path was set to search field only when searching. If the stream is selected and page is refreshed, the search was empty, this add stream path to search by default.