### PR TITLE
Add metric stream loading to nodes

### DIFF
--- a/src/components/Graphs/Graphs.stories.tsx
+++ b/src/components/Graphs/Graphs.stories.tsx
@@ -43,6 +43,22 @@ export const WithIntervalSelect = () => {
   )
 }
 
+export const WithDisabledInterval = () => {
+  return (
+    <Graphs>
+      <Graphs.TimeSeries
+        graphData={{ data }}
+        height="200px"
+        ratio="1:2"
+      />
+      <Graphs.Intervals
+        options={['24hours', '1month', '3months', 'all']}
+        disabled
+      />
+    </Graphs>
+  )
+}
+
 export const WithLoadingIndicator = () => {
   return (
     <Graphs>

--- a/src/components/Graphs/Intervals.tsx
+++ b/src/components/Graphs/Intervals.tsx
@@ -1,26 +1,25 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components/macro'
 
 import { useGraphContext, Interval } from './Graphs'
 
-type ChoiceProps = {
-  active: boolean,
-}
-
-const IntervalChoice = styled.div<ChoiceProps>`
+const IntervalChoice = styled.div`
   font-weight: 500;
   font-size: 12px;
   line-height: 32px;
-  color: ${(props) => props.active ? '#323232' : '#A3A3A3'};
-  background-color: ${(props) => props.active ? '#F8F8F8' : 'transparent'};
-  cursor: pointer;
+  color: ${({ theme }) => theme.active ? '#323232' : '#A3A3A3'};
+  background-color: ${({ theme }) => theme.active ? '#F8F8F8' : 'transparent'};
   padding: 0 13.5px;
   border-radius: 4px;
   user-select: none;
+  cursor: ${({ theme }) => !theme.disabled ? 'pointer' : 'not-allowed'};
+  opacity: ${({ theme }) => !theme.disabled ? '1' : '0.5'};
 `
 
 type IntervalsProps = {
   options: Array<Interval>,
+  disabled?: boolean,
+  onChange?: (interval: Interval) => void,
 }
 
 const labels = {
@@ -30,18 +29,34 @@ const labels = {
   'all': 'All data',
 }
 
-const UnstyledIntervals = ({ options, ...props }: IntervalsProps) => {
+const UnstyledIntervals = ({
+  options,
+  disabled,
+  onChange: onChangeProp,
+  ...props
+}: IntervalsProps) => {
   const { interval, setInterval } = useGraphContext()
+
+  const onClick = useCallback((nextInterval: Interval) => {
+    // typescript wtf :o
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    setInterval(nextInterval)
+
+    if (typeof onChangeProp === 'function') {
+      onChangeProp(nextInterval)
+    }
+  }, [setInterval, onChangeProp])
 
   return (
     <div {...props}>
       {(options || []).map((option) => (
         <IntervalChoice
           key={option}
-          // typescript wtf :o
-          // eslint-disable-next-line @typescript-eslint/no-implied-eval
-          onClick={() => setInterval(option)}
-          active={interval === option}
+          onClick={() => !disabled && onClick(option)}
+          theme={{
+            active: interval === option,
+            disabled: !!disabled,
+          }}
         >
           {labels[option] || option}
         </IntervalChoice>

--- a/src/components/Node/TopologyList.tsx
+++ b/src/components/Node/TopologyList.tsx
@@ -2,8 +2,9 @@ import React, { useMemo } from 'react'
 
 import { useStore } from '../../contexts/Store'
 import NodeList from '../NodeList'
+import StreamrClientProvider from '../StreamrClientProvider'
 
-import Error from '../Error'
+import NodeStats from '../NodeStats'
 
 type Props = {
   id?: string,
@@ -16,15 +17,16 @@ const TopologyList = ({ id }: Props) => {
 
   return currentNode ? (
     <NodeList>
-      <NodeList.Node
-        nodeId={currentNode.id}
-        title={currentNode.title}
-        placeName={currentNode.placeName}
-      >
-        <Error>
-          Couldn’t load node metrics
-        </Error>
-      </NodeList.Node>
+      <StreamrClientProvider>
+        <NodeList.Node
+          nodeId={currentNode.id}
+          title={currentNode.title}
+          placeName={currentNode.placeName}
+          showAddress
+        >
+          <NodeStats key={currentNode.id} id={currentNode.id} />
+        </NodeList.Node>
+      </StreamrClientProvider>
     </NodeList>
   ) : null
 }

--- a/src/components/NodeList/NodeListItem.tsx
+++ b/src/components/NodeList/NodeListItem.tsx
@@ -5,6 +5,7 @@ import Identicon from 'react-identicons'
 import { MONO, MEDIUM } from '../../utils/styled'
 import { truncate } from '../../utils/text'
 import Stats from '../Stats'
+import Graphs from '../Graphs'
 import Error from '../Error'
 
 const Name = styled.div`
@@ -46,6 +47,7 @@ const NodeElement = styled.div`
   }
 
   ${Stats},
+  ${Graphs},
   ${Error} {
     border-top: 1px solid #F5F5F5;
   }

--- a/src/components/NodeStats.tsx
+++ b/src/components/NodeStats.tsx
@@ -1,0 +1,199 @@
+import React, {
+  useMemo,
+  useCallback,
+  useState,
+  useEffect,
+} from 'react'
+import styled from 'styled-components'
+import { useSubscription } from 'streamr-client-react'
+
+import { getStream } from '../utils/api/streamr'
+import useIsMounted from '../hooks/useIsMounted'
+import {
+  SANS,
+  MEDIUM,
+} from '../utils/styled'
+
+import Stats from './Stats'
+import Graphs from './Graphs'
+import Error from './Error'
+
+const GraphPlaceholder = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #A3A3A3;
+  font-family: ${SANS};
+  font-weight: ${MEDIUM};
+  text-transform: uppercase;
+`
+
+const ONE_DAY = 24 * 60 * 60 * 1000
+const startDate = new Date(2020, 1, 1, 10).getTime()
+
+const data = [
+  {
+    x: startDate,
+    y: 1,
+  },
+  {
+    x: startDate + 1 * ONE_DAY,
+    y: 5,
+  },
+  {
+    x: startDate + 2 * ONE_DAY,
+    y: 4,
+  },
+  {
+    x: startDate + 3 * ONE_DAY,
+    y: 12,
+  },
+]
+
+type NodeGraphProps = {
+  streamId?: string,
+}
+
+const NodeGraph = ({ streamId }: NodeGraphProps) => {
+  // TODO: subscribe to stream, display data
+
+  /*
+  useSubscription({
+    stream: streamId,
+    resend: {
+      last: 1,
+    },
+  }, onMessage)
+  */
+
+  return (
+    <Graphs.TimeSeries
+      graphData={{ data }}
+      height="200px"
+      ratio="1:2"
+      showCrosshair
+    />
+  )
+}
+
+type Props = {
+  id?: string,
+}
+
+const NodeGraphLoader = ({ id }: Props) => {
+  const [hasLoaded, setHasLoaded] = useState(false)
+  const [error, setError] = useState<string | undefined>(undefined)
+  const [interval, setInterval] = useState<string>('24hours')
+  const isMounted = useIsMounted()
+
+  const metricStreamId = useMemo(() => `${id}/streamr/node/metrics/${interval}`, [id, interval])
+  // const metricStreamId = 'Y1gWr4X9S8mQdg5mzBq1dA'
+
+  const loadStream = useCallback(async (nodeId) => {
+    setHasLoaded(false)
+    setError(undefined)
+
+    try {
+      await getStream({ id: nodeId })
+    } catch (e) {
+      setError('Metric data not available')
+    } finally {
+      if (isMounted()) {
+        setHasLoaded(true)
+      }
+    }
+  }, [isMounted])
+
+  useEffect(() => {
+    loadStream(metricStreamId)
+  }, [loadStream, metricStreamId])
+
+  return (
+    <>
+      <Graphs defaultInterval="24hours">
+        {(!hasLoaded || !!error) && (
+          <>
+            <GraphPlaceholder>
+              {!!error && (
+                <span>{error}</span>
+              )}
+            </GraphPlaceholder>
+            <Graphs.Loading loading={!error} row={2} />
+          </>
+        )}
+        {!!hasLoaded && !error && (
+          <NodeGraph streamId={metricStreamId} />
+        )}
+        <Graphs.Intervals
+          options={['24hours', '1month', '3months', 'all']}
+          onChange={setInterval}
+        />
+      </Graphs>
+      {!!error && (
+        <Error>
+          {error}
+        </Error>
+      )}
+    </>
+  )
+}
+
+const NodeStats = ({ id }: Props) => {
+  const [selectedStat, setSelectedStat] = useState<string | undefined>(undefined)
+
+  const toggleStat = useCallback((name) => {
+    setSelectedStat((prev) => prev !== name ? name : undefined)
+  }, [])
+
+  const [messagesPerSecond, setMessagesPersecond] = useState<number | undefined>(undefined)
+  const isMounted = useIsMounted()
+
+  const onMessagesPerSecond = useCallback(({
+    eventsPerSecond,
+  }) => {
+    if (isMounted()) {
+      setMessagesPersecond(eventsPerSecond)
+    }
+  }, [isMounted])
+
+  // TODO: use network metric for now, replace with real value
+  // const metricStreamId = useMemo(() => `${id}/streamr/node/metrics/sec`, [id])
+  const metricStreamId = 'Y1gWr4X9S8mQdg5mzBq1dA'
+
+  useSubscription({
+    stream: metricStreamId,
+    resend: {
+      last: 1,
+    },
+  }, onMessagesPerSecond)
+
+  return (
+    <>
+      <Stats active={selectedStat}>
+        <Stats.Stat
+          id="messagesPerSecond"
+          label="Msgs / sec"
+          value={messagesPerSecond}
+          onClick={() => toggleStat('messagesPerSecond')}
+        />
+        <Stats.Stat
+          id="mbPerSecond"
+          label="Mb / s"
+          value={undefined}
+          onClick={() => toggleStat('mbPerSecond')}
+        />
+        <Stats.Stat
+          id="latency"
+          label="Latency ms"
+          value={undefined}
+          onClick={() => toggleStat('latency')}
+        />
+      </Stats>
+      {!!selectedStat && (
+        <NodeGraphLoader id={id} />
+      )}
+    </>
+  )
+}
+
+export default NodeStats

--- a/src/components/Stream/TopologyList.tsx
+++ b/src/components/Stream/TopologyList.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react'
 import { useParams, useHistory } from 'react-router-dom'
+import StreamrClientProvider from '../StreamrClientProvider'
 
 import { useStore } from '../../contexts/Store'
 import { truncate } from '../../utils/text'
 import NodeList from '../NodeList'
-import Error from '../Error'
+import NodeStats from '../NodeStats'
 
 type Props = {
   id: string,
@@ -28,33 +29,33 @@ const TopologyList = ({ id }: Props) => {
   const streamTitle = stream && stream.name || id
 
   return (
-    <NodeList>
-      <NodeList.Header>
-        Showing
-        {' '}
-        <strong>{visibleNodes.length}</strong>
-        {' '}
-        nodes carrying the stream
-        {' '}
-        <strong title={id}>{truncate(streamTitle)}</strong>
-      </NodeList.Header>
-      {visibleNodes.map(({ id: nodeId, title, placeName }) => (
-        <NodeList.Node
-          key={nodeId}
-          nodeId={nodeId}
-          title={title}
-          placeName={placeName}
-          onClick={toggleNode}
-          showAddress={activeNodeId === nodeId}
-        >
-          {activeNodeId === nodeId && (
-            <Error>
-              Couldn’t load node metrics
-            </Error>
-          )}
-        </NodeList.Node>
-      ))}
-    </NodeList>
+    <StreamrClientProvider>
+      <NodeList>
+        <NodeList.Header>
+          Showing
+          {' '}
+          <strong>{visibleNodes.length}</strong>
+          {' '}
+          nodes carrying the stream
+          {' '}
+          <strong title={id}>{truncate(streamTitle)}</strong>
+        </NodeList.Header>
+        {visibleNodes.map(({ id: nodeId, title, placeName }) => (
+          <NodeList.Node
+            key={nodeId}
+            nodeId={nodeId}
+            title={title}
+            placeName={placeName}
+            onClick={toggleNode}
+            showAddress={activeNodeId === nodeId}
+          >
+            {activeNodeId === nodeId && (
+              <NodeStats id={nodeId} />
+            )}
+          </NodeList.Node>
+        ))}
+      </NodeList>
+    </StreamrClientProvider>
   )
 }
 


### PR DESCRIPTION
Adds loading of metrics stream to nodes when clicking on the stats. It loads the stream data first before making a subscription, in case the stream doesn't exist (which it doesn't atm).