### PR TITLE
[FRONT-293] Update map style, typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21796,9 +21796,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.4.tgz",
-      "integrity": "sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg=="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
+      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og=="
     },
     "ua-parser-js": {
       "version": "0.7.23",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "streamr-client-react": "^1.1.1",
     "styled-components": "^5.1.1",
     "supercluster": "^7.1.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.0.7",
     "use-supercluster": "^0.2.8"
   },
   "scripts": {

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -150,7 +150,7 @@ export const Map = ({
     <ReactMapGL
       {...viewport}
       mapboxApiAccessToken={MAPBOX_TOKEN}
-      mapStyle='mapbox://styles/mattinnes/ckdtszq5m0iht19qk0zuz52oy'
+      mapStyle='mapbox://styles/mattinnes/cklaehqgx01yh17pdfs03tt8t'
       onViewportChange={setViewport}
       ref={mapRef}
       onClick={onMapClick}


### PR DESCRIPTION
Update map style + downgrade typescript version to get rid of `eslint` warning