### PR TITLE
[FRONT-302] Enable mock data API

### DIFF
--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -7,8 +7,25 @@ import { getReversedGeocodedLocation } from './mapbox'
 import { get } from '../request'
 import getConfig from '../config'
 
+const getTrackerRegistry = async () => {
+  const { tracker } = getConfig()
+
+  if (tracker.source === 'http') {
+    return {
+      getAllTrackers: () => ([{
+        http: tracker.http,
+      }]),
+      getTracker: () => ({
+        http: tracker.http,
+      }),
+    }
+  }
+
+  return Utils.getTrackerRegistryFromContract(tracker)
+}
+
 export const getTrackers = async (): Promise<string[]> => {
-  const trackerRegistry = await Utils.getTrackerRegistryFromContract(getConfig().tracker)
+  const trackerRegistry = await getTrackerRegistry()
 
   const result: string[] = (trackerRegistry.getAllTrackers() || [])
     .map(({ http }: { http: string }) => http)
@@ -22,7 +39,7 @@ export const getTrackerForStream = async (options: { id: string, partition?: num
     ...({ id: undefined, partition: 0 }),
     ...options,
   }
-  const trackerRegistry = await Utils.getTrackerRegistryFromContract(getConfig().tracker)
+  const trackerRegistry = await getTrackerRegistry()
 
   const { http } = trackerRegistry.getTracker(id, partition)
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,5 @@
 import { isLocalStorageAvailable } from './storage'
-import envs from './envs'
+import envs, { EnvConfig } from './envs'
 
 export const APP_ENV_KEY = 'network-eplorer.env'
 const storage = isLocalStorageAvailable() ? window.localStorage : null
@@ -13,7 +13,7 @@ export function setEnvironment(value: string) {
   storage.setItem(APP_ENV_KEY, JSON.stringify(value))
 }
 
-function getConfig(options = {}) {
+function getConfig(options = {}): EnvConfig {
   const { env } = {
     ...({
       env: getEnvironment() || 'local',

--- a/src/utils/envs.ts
+++ b/src/utils/envs.ts
@@ -1,8 +1,14 @@
-type EnvConfig = {
-  tracker: {
-    contractAddress: string,
-    jsonRpcProvider: string,
-  },
+type TrackerConfig = {
+  source: 'contract',
+  contractAddress: string,
+  jsonRpcProvider: string,
+} | {
+  source: 'http',
+  http: string,
+}
+
+export type EnvConfig = {
+  tracker: TrackerConfig,
   streamr: {
     http: string,
     ws: string,
@@ -12,8 +18,19 @@ type EnvConfig = {
 type Envs = Record<string, EnvConfig>
 
 const envs: Envs = {
+  'mock-api': {
+    tracker: {
+      source: 'http',
+      http: 'http://localhost:3001',
+    },
+    streamr: {
+      http: 'http://localhost:3001',
+      ws: 'http://localhost:3001',
+    },
+  },
   local: {
     tracker: {
+      source: 'contract',
       contractAddress: process.env.REACT_APP_TRACKER_REGISTRY_ADDRESS || '',
       jsonRpcProvider: process.env.REACT_APP_TRACKER_REGISTRY_PROVIDER || '',
     },
@@ -24,6 +41,7 @@ const envs: Envs = {
   },
   production: {
     tracker: {
+      source: 'contract',
       contractAddress: '0xb21df4018dee577cd33f5b99f269ea7b23b8e6eb',
       jsonRpcProvider: 'https://mainnet.infura.io/v3/17c3985baecb4c4d94a1edc2c4d23206',
     },


### PR DESCRIPTION
Enables running a mock API along with the `local` and `production` options.

To make it work:

- install the mock API here: https://github.com/streamr-dev/network-explorer-mock-api
- run `npm ci` and `npm start`, mock api starts in port 3001
- Run the app and select `mock-api` from the debug window