### PR TITLE
Fix indexed nodes calculation

### DIFF
--- a/src/components/StreamStats.tsx
+++ b/src/components/StreamStats.tsx
@@ -19,7 +19,7 @@ type StatsState = {
   latency?: number | undefined,
 }
 
-const NetworkStats = () => {
+const StreamStats = () => {
   const isMounted = useIsMounted()
   const [messagesPerSecond, setMessagesPerSecond] = useState<number | undefined>()
   const [selectedStat, setSelectedStat] = useState<MetricType | undefined>(undefined)
@@ -29,13 +29,18 @@ const NetworkStats = () => {
   useEffect(() => {
     if (!latencies || Object.keys(latencies).length <= 0) { return }
 
-    const indexedNodes = getIndexedNodes(latencies)
+    try {
+      const indexedNodes = getIndexedNodes(latencies)
 
-    calculateShortestPaths(indexedNodes, ({ averageDistance }: QuickDijkstraResult) => {
-      if (isMounted()) {
-        setLatency(averageDistance)
-      }
-    })
+      calculateShortestPaths(indexedNodes, ({ averageDistance }: QuickDijkstraResult) => {
+        if (isMounted()) {
+          setLatency(averageDistance)
+        }
+      })
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(e)
+    }
   }, [latencies, isMounted])
 
   const toggleStat = useCallback((name) => {
@@ -85,4 +90,4 @@ const NetworkStats = () => {
   )
 }
 
-export default NetworkStats
+export default StreamStats

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -133,12 +133,12 @@ export const getIndexedNodes = (topology: Topology): GraphLink[] => {
   const nodeIds: { [nodeId: string]: number } = {}
 
   Object.keys(topology || {}).forEach((nodeId) => {
-    if (!nodeIds[nodeId]) {
+    if (!isNumber(nodeIds[nodeId])) {
       nodeIds[nodeId] = Object.keys(nodeIds).length
     }
 
     Object.keys(topology[nodeId] || {}).forEach((neighborId) => {
-      if (!nodeIds[neighborId]) {
+      if (!isNumber(nodeIds[neighborId])) {
         nodeIds[neighborId] = Object.keys(nodeIds).length
       }
 
@@ -148,11 +148,10 @@ export const getIndexedNodes = (topology: Topology): GraphLink[] => {
         const a = nodeIds[nodeId]
         const b = nodeIds[neighborId]
 
-        if (a < b) {
-          matrix.set(JSON.stringify([a, b]), Math.round((topology[nodeId][neighborId] || 0) / 2))
-        } else {
-          matrix.set(JSON.stringify([b, a]), Math.round((topology[nodeId][neighborId] || 0) / 2))
-        }
+        matrix.set(
+          JSON.stringify((a < b) ? [a, b] : [b, a]),
+          Math.round((topology[nodeId][neighborId] || 0) / 2),
+        )
       }
     })
   })

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -121,18 +121,16 @@ export const getTopologyFromResponse = (response: TopologyResult): Topology => (
 
 const isNumber = (value: number | undefined) => typeof value === 'number' && isFinite(value)
 
-type MapValue = [target: number, weight: number]
-
 export const getIndexedNodes = (topology: Topology): GraphLink[] => {
   const ret: GraphLink[] = []
 
-  const matrix:  Map<number, MapValue> = new Map<number, MapValue>()
+  const matrix:  Map<string, number> = new Map<string, number>()
 
   // build a mapping from links with arbitrary node ids to links with integer ids,
   // the integer id is based on the first occurence of the node in the data and
   // convert links to integer format using the mapping created,
   // ignoring NULL rtts
-  const nodeIds: {[nodeId: string]: number} = {}
+  const nodeIds: { [nodeId: string]: number } = {}
 
   Object.keys(topology || {}).forEach((nodeId) => {
     if (!nodeIds[nodeId]) {
@@ -151,16 +149,17 @@ export const getIndexedNodes = (topology: Topology): GraphLink[] => {
         const b = nodeIds[neighborId]
 
         if (a < b) {
-          matrix.set(a, [b, Math.round((topology[nodeId][neighborId] || 0) / 2)])
+          matrix.set(JSON.stringify([a, b]), Math.round((topology[nodeId][neighborId] || 0) / 2))
         } else {
-          matrix.set(b, [a, Math.round((topology[nodeId][neighborId] || 0) / 2)])
+          matrix.set(JSON.stringify([b, a]), Math.round((topology[nodeId][neighborId] || 0) / 2))
         }
       }
     })
   })
 
   for (const [key, value] of  matrix.entries()) {
-    ret.push([key, value[0], value[1]])
+    const [nodeIndex, neighborIndex] = JSON.parse(key)
+    ret.push([nodeIndex, neighborIndex, value])
   }
 
   return ret


### PR DESCRIPTION
There was an error with the `getIndexedNodes` calculation, this (and the previous) code is adapted from https://github.com/streamr-dev/quick-dijkstra/blob/1.1.0/examples/wasm/typescript-webpack/src/explorerconverter.ts