### PR TITLE
[FRONT-296] Add node connection toggle

### DIFF
--- a/src/components/Map/ConnectionLayer.tsx
+++ b/src/components/Map/ConnectionLayer.tsx
@@ -54,21 +54,13 @@ const getNodeConnections = (
 type Props = {
   topology: Topology,
   nodes: Node[],
-}
-
-const layerStyle = {
-  id: 'node-connections-layer',
-  type: 'line',
-  paint: {
-    'line-width': 1,
-    'line-color': '#0324FF',
-    'line-dasharray': [5, 5],
-  },
+  visible?: boolean,
 }
 
 const ConnectionLayer = ({
   topology,
   nodes,
+  visible,
 }: Props) => {
   const geoJsonLines: GeoJSON.FeatureCollection<GeoJSON.Geometry> = useMemo(() => {
     const connections = getNodeConnections(topology, nodes)
@@ -90,7 +82,15 @@ const ConnectionLayer = ({
 
   return (
     <Source id="node-connections-source" type="geojson" data={geoJsonLines}>
-      <Layer {...layerStyle} />
+      <Layer
+        id="node-connections-layer"
+        type="line"
+        paint={{
+          'line-width': 1,
+          'line-color': '#0324FF',
+          'line-opacity': visible ? 1 : 0,
+        }}
+      />
     </Source>
   )
 }

--- a/src/components/Map/Map.stories.tsx
+++ b/src/components/Map/Map.stories.tsx
@@ -140,6 +140,49 @@ export const ZoomControls: Story = (args) => {
   )
 }
 
+export const NodeConnections: Story = (args) => {
+  const [viewport, setViewport] = useState<ViewportProps>(initialViewport)
+  const [showConnections, setShowConnections] = useState<boolean>(true)
+
+  const onToggleConnections = useCallback(() => {
+    setShowConnections((wasShown) => !wasShown)
+  }, [])
+
+  const onZoomIn = useCallback(() => {
+    setViewport((prev) => ({
+      ...prev,
+      zoom: prev.zoom + 1,
+    }))
+  }, [setViewport])
+
+  const onZoomOut = useCallback(() => {
+    setViewport((prev) => ({
+      ...prev,
+      zoom: prev.zoom - 1,
+    }))
+  }, [setViewport])
+
+  const onZoomReset = useCallback(() => {
+    setViewport((prev) => ({
+      ...initialViewport,
+    }))
+  }, [setViewport])
+
+  return (
+    <Map
+      nodes={nodes}
+      topology={topology}
+      viewport={viewport}
+      setViewport={setViewport}
+      onZoomIn={onZoomIn}
+      onZoomOut={onZoomOut}
+      onZoomReset={onZoomReset}
+      showConnections={showConnections}
+      onToggleConnections={onToggleConnections}
+    />
+  )
+}
+
 export const OverlappingNodes: Story = (args) => {
   const [viewport, setViewport] = useState<ViewportProps>({
     width: 800,

--- a/src/components/Map/NavigationControl.tsx
+++ b/src/components/Map/NavigationControl.tsx
@@ -50,19 +50,35 @@ const PlusIcon = () => (
   </svg>
 )
 
+const ConnectionIcon = () => (
+  <svg width="18" height="16" viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 5.49902C10.1046 5.49902 11 4.60359 11 3.49902C11 2.39445 10.1046 1.49902 9 1.49902C7.89543 1.49902 7 2.39445 7 3.49902C7 4.60359 7.89543 5.49902 9 5.49902Z" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3.5 14.499C4.60457 14.499 5.5 13.6036 5.5 12.499C5.5 11.3945 4.60457 10.499 3.5 10.499C2.39543 10.499 1.5 11.3945 1.5 12.499C1.5 13.6036 2.39543 14.499 3.5 14.499Z" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M14.5 14.499C15.6046 14.499 16.5 13.6036 16.5 12.499C16.5 11.3945 15.6046 10.499 14.5 10.499C13.3954 10.499 12.5 11.3945 12.5 12.499C12.5 13.6036 13.3954 14.499 14.5 14.499Z" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M5.5 12.499H12.5" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M10.106 5.16504L13.6273 10.6984" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M7.89389 5.16504L4.37256 10.6984" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
 export type Props = {
   onZoomIn?: () => void,
   onZoomOut?: () => void,
   onZoomReset?: () => void,
+  onToggleConnections?: () => void,
 }
 
 const UnstyledNavigationControl = ({
   onZoomIn,
   onZoomOut,
   onZoomReset,
+  onToggleConnections,
   ...props
 }: Props) => (
   <div {...props}>
+    {typeof onToggleConnections === 'function' && (
+      <Button type="button" onClick={() => onToggleConnections()}><ConnectionIcon /></Button>
+    )}
     {typeof onZoomReset === 'function' && (
       <ResetButton type="button" onClick={() => onZoomReset()}><RefreshIcon /></ResetButton>
     )}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -34,6 +34,7 @@ type Props = {
   setViewport: React.Dispatch<React.SetStateAction<ViewportProps>>,
   onNodeClick?: (v: string) => void,
   onMapClick?: () => void,
+  showConnections?: boolean,
 } & NavigationControlProps
 
 const defaultViewport = {
@@ -62,6 +63,8 @@ export const Map = ({
   onZoomIn,
   onZoomOut,
   onZoomReset,
+  onToggleConnections,
+  showConnections = false,
 }: Props) => {
   const mapRef = useRef<InteractiveMap>(null)
 
@@ -79,6 +82,7 @@ export const Map = ({
       <ConnectionLayer
         topology={topology}
         nodes={nodes}
+        visible={!!showConnections}
       />
       <MarkerLayer
         nodes={nodes}
@@ -89,6 +93,7 @@ export const Map = ({
         onZoomIn={onZoomIn}
         onZoomOut={onZoomOut}
         onZoomReset={onZoomReset}
+        onToggleConnections={onToggleConnections}
       />
     </ReactMapGL>
   )
@@ -114,6 +119,8 @@ export const ConnectedMap = () => {
     activeLocation,
     streamId,
     setActiveView,
+    showConnections,
+    toggleShowConnections,
   } = useStore()
   const history = useHistory()
   const [viewport, setViewport] = useState<ViewportProps>({
@@ -219,6 +226,8 @@ export const ConnectedMap = () => {
         onZoomIn={zoomIn}
         onZoomOut={zoomOut}
         onZoomReset={reset}
+        showConnections={(showConnections === 'auto' && !!streamId) || showConnections === 'always'}
+        onToggleConnections={toggleShowConnections}
       />
     </MapContainer>
   )

--- a/src/contexts/Store.test.jsx
+++ b/src/contexts/Store.test.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 
-import { Provider as StoreProvider, useStore } from './Store'
+import { Provider as StoreProvider, useStore, ConnectionsMode } from './Store'
 
 let container
 
@@ -243,6 +243,80 @@ describe('Store', () => {
       })
 
       expect(store.stream).toStrictEqual(undefined)
+    })
+  })
+
+  describe('showConnections', () => {
+    it('has auto mode by default', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      expect(store.showConnections).toStrictEqual(ConnectionsMode.Auto)
+    })
+
+    it('toggles connections on if no stream set', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      expect(store.showConnections).toStrictEqual(ConnectionsMode.Auto)
+
+      act(() => {
+        store.toggleShowConnections()
+      })
+
+      expect(store.showConnections).toStrictEqual(ConnectionsMode.Always)
+    })
+
+    it('toggles connections off if stream is set', () => {
+      let store
+
+      function Test() {
+        store = useStore()
+
+        return null
+      }
+
+      render((
+        <StoreProvider>
+          <Test />
+        </StoreProvider>
+      ), container)
+
+      expect(store.showConnections).toStrictEqual(ConnectionsMode.Auto)
+
+      act(() => {
+        act(() => {
+          store.setStream({
+            id: '0x123/test/stream',
+            description: 'My test stream',
+          })
+        })
+        store.toggleShowConnections()
+      })
+
+      expect(store.showConnections).toStrictEqual(ConnectionsMode.Off)
     })
   })
 })

--- a/src/contexts/Store.tsx
+++ b/src/contexts/Store.tsx
@@ -25,6 +25,12 @@ export enum ActiveView {
 
 export type Topology = Record<string, string[]>
 
+export enum ConnectionsMode {
+  Auto = 'auto',
+  Always = 'always',
+  Off = 'off',
+}
+
 type Store = {
   env: string | undefined,
   activeView: ActiveView,
@@ -37,6 +43,7 @@ type Store = {
   activeNodeId: string | undefined,
   activeLocationId: string | undefined,
   entities: { [key: string]: any }, // eslint-disable-line @typescript-eslint/no-explicit-any
+  showConnections: ConnectionsMode,
 }
 
 type ContextProps = {
@@ -54,6 +61,8 @@ type ContextProps = {
   trackers: string[],
   setTrackers: (trackers: string[]) => void,
   topology: Topology,
+  showConnections: ConnectionsMode
+  toggleShowConnections: () => void,
   latencies: trackerApi.Topology,
   setTopology: (topology: trackerApi.Topology) => void,
   setActiveNodeId: (activeNodeId?: string) => void,
@@ -86,6 +95,7 @@ const getInitialState = (): Store => ({
     streams: {},
     searchResults: {},
   },
+  showConnections: ConnectionsMode.Auto,
 })
 
 type Action =
@@ -98,6 +108,7 @@ type Action =
  | { type: 'setStream', streamId: string | undefined }
  | { type: 'setActiveView', activeView: ActiveView }
  | { type: 'toggleActiveView' }
+ | { type: 'toggleShowConnections' }
  | { type: 'updateSearch', search: string }
  | { type: 'addSearchResults', ids: Array<any> } // eslint-disable-line @typescript-eslint/no-explicit-any
  | { type: 'resetSearchResults' }
@@ -164,6 +175,23 @@ const reducer = (state: Store, action: Action) => {
       return {
         ...state,
         activeView: state.activeView === ActiveView.Map ? ActiveView.List : ActiveView.Map,
+      }
+    }
+
+    case 'toggleShowConnections': {
+      // handle initial special case
+      if (state.showConnections === ConnectionsMode.Auto) {
+        return {
+          ...state,
+          showConnections: state.streamId ? ConnectionsMode.Off : ConnectionsMode.Always,
+        }
+      }
+
+      return {
+        ...state,
+        showConnections: (state.showConnections !== ConnectionsMode.Off) ?
+          ConnectionsMode.Off :
+          ConnectionsMode.Always,
       }
     }
 
@@ -283,6 +311,12 @@ function useStoreContext() {
     })
   }, [])
 
+  const toggleShowConnections = useCallback(() => {
+    dispatch({
+      type: 'toggleShowConnections',
+    })
+  }, [])
+
   const resetStore = useCallback(() => {
     dispatch({
       type: 'reset',
@@ -328,6 +362,7 @@ function useStoreContext() {
     trackers,
     latencies,
     entities,
+    showConnections,
   } = store
 
   // Use ref to avoid unnecessary redraws when entities update
@@ -383,6 +418,8 @@ function useStoreContext() {
     latencies,
     setTopology,
     visibleNodes,
+    showConnections,
+    toggleShowConnections,
     activeNode,
     activeLocation,
     setActiveNodeId,
@@ -410,6 +447,8 @@ function useStoreContext() {
     latencies,
     setTopology,
     visibleNodes,
+    showConnections,
+    toggleShowConnections,
     activeNode,
     activeLocation,
     setActiveNodeId,


### PR DESCRIPTION
Adds node connections toggle to map navigation control. By default, does not show topology in main page but in stream page it does.

FYI, navigation control position in mobile handled in #53 