### PR TITLE
[FRONT-327] Map view updates

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import {
   BrowserRouter,
   Route,
   Switch,
+  useLocation,
 } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -15,7 +16,7 @@ import UnstyledLoadingIndicator from '../components/LoadingIndicator'
 import Layout from '../components/Layout'
 import ErrorBoundary from '../components/ErrorBoundary'
 
-import { Provider as StoreProvider } from '../contexts/Store'
+import { Provider as StoreProvider, useStore } from '../contexts/Store'
 import { Provider as ControllerProvider, useController } from '../contexts/Controller'
 import { Provider as Pendingrovider, usePending } from '../contexts/Pending'
 
@@ -29,6 +30,26 @@ function useLoadTrackersEffect() {
 
 const TrackerLoader = () => {
   useLoadTrackersEffect()
+  return null
+}
+
+function useResetSearchTextEffect() {
+  const {
+    updateSearch: updateSearchText,
+    resetSearchResults,
+  } = useStore()
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    if (pathname === '/') {
+      updateSearchText('')
+      resetSearchResults()
+    }
+  }, [updateSearchText, resetSearchResults, pathname])
+}
+
+const SearchTextResetter = () => {
+  useResetSearchTextEffect()
   return null
 }
 
@@ -61,6 +82,7 @@ const App = () => (
           <Layout>
             <ErrorBoundary>
               <TrackerLoader />
+              <SearchTextResetter />
               <Debug />
               <SearchBox />
               <Switch>

--- a/src/components/Map/ConnectionLayer.tsx
+++ b/src/components/Map/ConnectionLayer.tsx
@@ -88,7 +88,7 @@ const ConnectionLayer = ({
         paint={{
           'line-width': 1,
           'line-color': '#0324FF',
-          'line-opacity': visible ? 1 : 0,
+          'line-opacity': visible ? 0.5 : 0,
         }}
       />
     </Source>

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -23,6 +23,21 @@ type NodeProps = {
   id: string,
 }
 
+const SearchTextSetter = () => {
+  const {
+    updateSearch: updateSearchText,
+    activeNode,
+  } = useStore()
+
+  const activeNodeTitle = activeNode && activeNode.title
+
+  useEffect(() => {
+    updateSearchText(activeNodeTitle || '')
+  }, [updateSearchText, activeNodeTitle])
+
+  return null
+}
+
 const ActiveNodeSetter = ({ id }: NodeProps) => {
   const { setActiveNodeId } = useStore()
 
@@ -49,6 +64,7 @@ export default () => {
 
   return (
     <>
+      <SearchTextSetter />
       <NodeConnectionsLoader />
       <ActiveNodeSetter id={nodeId} />
       {!!nodeId && (

--- a/src/components/SearchBox/SearchBox.stories.tsx
+++ b/src/components/SearchBox/SearchBox.stories.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 import { Meta } from '@storybook/react/types-6-0'
-import { MemoryRouter } from 'react-router-dom'
 
 import { SearchResult } from '../../utils/api/streamr'
 import Stats from '../Stats'
@@ -14,7 +13,6 @@ import SearchBox from '.'
 export default {
   title: 'SearchBox',
   component: SearchBox,
-  decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>],
 } as Meta
 
 const Wrapper = styled.div`

--- a/src/components/SearchBox/SearchInput.tsx
+++ b/src/components/SearchBox/SearchInput.tsx
@@ -7,7 +7,6 @@ import React, {
   useEffect,
 } from 'react'
 import styled from 'styled-components/macro'
-import { Link } from 'react-router-dom'
 import { truncate } from '../../utils/text'
 
 import { SM, MD, SANS } from '../../utils/styled'
@@ -56,13 +55,19 @@ const Logo = styled.div`
     display: block;
   }
 
-  svg {
+  button {
     position: absolute;
     width: 32px;
     height: 32px;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
+    appearance: none;
+    border: none;
+    background: none;
+    outline: none;
+    margin: 0;
+    padding: 0;
   }
 `
 
@@ -193,9 +198,9 @@ const UnstyledSearchInput = ({
     >
       <Inner>
         <Logo>
-          <Link to="/">
+          <button type="button" onClick={onClear}>
             <StreamrIcon />
-          </Link>
+          </button>
         </Logo>
         <Input
           id="input"

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -40,15 +40,14 @@ const SearchBox = () => {
   }, [updateSearch])
 
   const onResultClick = useCallback(({ id, type }) => {
+    setActiveView(ActiveView.Map)
     switch (type) {
       case 'streams':
-        updateSearchText(id)
         resetSearchResults()
         history.push(`/streams/${encodeURIComponent(id)}`)
         break
 
       case 'nodes':
-        updateSearchText('')
         resetSearchResults()
         history.push(`/nodes/${id}`)
         break
@@ -60,7 +59,7 @@ const SearchBox = () => {
       default:
         break
     }
-  }, [history, setActiveLocationId, updateSearchText, resetSearchResults])
+  }, [setActiveView, history, setActiveLocationId, resetSearchResults])
 
   return (
     <Search

--- a/src/components/Stream/index.tsx
+++ b/src/components/Stream/index.tsx
@@ -10,12 +10,20 @@ type StreamProps = {
   id: string,
 }
 
-const TopologyLoader = ({ id }: StreamProps) => {
-  const { loadTopology, resetTopology } = useController()
+const SearchTextSetter = ({ id }: StreamProps) => {
   const { updateSearch } = useStore()
 
   useEffect(() => {
     updateSearch(id)
+  }, [updateSearch, id])
+
+  return null
+}
+
+const TopologyLoader = ({ id }: StreamProps) => {
+  const { loadTopology, resetTopology } = useController()
+
+  useEffect(() => {
     loadTopology({
       streamId: id,
     })
@@ -23,7 +31,7 @@ const TopologyLoader = ({ id }: StreamProps) => {
     return () => {
       resetTopology()
     }
-  }, [loadTopology, resetTopology, updateSearch, id])
+  }, [loadTopology, resetTopology, id])
 
   return null
 }
@@ -75,6 +83,7 @@ export default () => {
 
   return (
     <>
+      <SearchTextSetter id={streamId} />
       <TopologyLoader id={streamId} />
       <StreamLoader id={streamId} />
       <ActiveNodeSetter id={nodeId} />


### PR DESCRIPTION
Fixes:

* Connection lines should be 50% opacity
* Deselecting a node. Added deselect by clicking anywhere on the map (except on another node). Clicking again on the same node should also deselect. If you select a node, it should also show in the search box.
* Change cursor when dragging map, default cursor is `default` (standard pointer), on drag `all-scroll` (4 way arrow)

Seems that cursor change does not work in Safari where it changes to text cursor when dragging.