### PR TITLE
[FRONT-420] Fix metrics underline display alignment

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -114,10 +114,15 @@ const InfinityIcon = () => (
 )
 
 const ButtonGrid = styled.div`
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
+  flex-direction: row;
   padding-top: 12px;
   font-family: ${SANS};
+
+  > ${Stat} {
+      flex-grow: 1;
+      flex-basis: 0;
+  }
 `
 
 const Underline = styled.div`


### PR DESCRIPTION
> Captions (MSGS / SEC etc) & numbers aren’t centred in each section, as you can see from the Staging images: numbers and blue underlines are not aligned. The problem seems to be the same in both the Global display & individual node display

Fixes metrics underline display alignment.