### PR TITLE
[FRONT-416] Sort graph data

### DIFF
--- a/src/components/Graphs/TimeSeriesGraph.stories.tsx
+++ b/src/components/Graphs/TimeSeriesGraph.stories.tsx
@@ -48,6 +48,7 @@ const data2 = [
     y: 9,
   },
 ]
+
 const Template: Story<Props> = (args) => (
   <TimeSeries {...args} />
 )

--- a/src/components/MetricGraph.tsx
+++ b/src/components/MetricGraph.tsx
@@ -135,6 +135,8 @@ const MetricGraph = ({ streamId, interval, metric }: MetricGraphProps) => {
         x: timestamp,
         y: rawValue[nextMetric],
       }))
+      .sort(({ x: prev }, { x: current }) => (prev - current))
+
     setValues(nextValues)
 
     graphPollTimeout.current = setTimeout(() => {


### PR DESCRIPTION
Add sorting to incoming metric data to avoid messed upped looking graphs. I think when that happens the data points are coming out of order and the graph goes crazy. Also added a data domain for the X-axis, that seems to do some sorting as well.