### PR TITLE
Add realtime graph

### DIFF
--- a/src/components/Graphs/Graphs.tsx
+++ b/src/components/Graphs/Graphs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useContext } from 'react'
 
-export type Interval = '24hours' | '1month' | '3months' | 'all'
+export type Interval = 'realtime' | '24hours' | '1month' | '3months' | 'all'
 
 type ContextProps = {
   interval: Interval | undefined,

--- a/src/components/Graphs/Intervals.tsx
+++ b/src/components/Graphs/Intervals.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 
 import { useGraphContext, Interval } from './Graphs'
 
@@ -9,11 +9,19 @@ const IntervalChoice = styled.div`
   line-height: 32px;
   color: ${({ theme }) => theme.active ? '#323232' : '#A3A3A3'};
   background-color: ${({ theme }) => theme.active ? '#F8F8F8' : 'transparent'};
-  padding: 0 13.5px;
+  padding: 0;
   border-radius: 4px;
   user-select: none;
   cursor: ${({ theme }) => !theme.disabled ? 'pointer' : 'not-allowed'};
   opacity: ${({ theme }) => !theme.disabled ? '1' : '0.5'};
+  white-space: nowrap;
+  min-width: 56px;
+  box-sizing: border-box;
+  text-align: center;
+
+  ${({ theme }) => !!theme.letterSpacing && css`
+    letter-spacing: 0.04rem;
+  `}
 `
 
 type IntervalsProps = {
@@ -23,10 +31,11 @@ type IntervalsProps = {
 }
 
 const labels = {
-  '24hours': '24 Hours',
-  '1month': '1 Month',
-  '3months': '3 Months',
-  'all': 'All data',
+  'realtime': 'LIVE',
+  '24hours': '24H',
+  '1month': '1M',
+  '3months': '3M',
+  'all': 'ALL',
 }
 
 const UnstyledIntervals = ({
@@ -56,6 +65,7 @@ const UnstyledIntervals = ({
           theme={{
             active: interval === option,
             disabled: !!disabled,
+            letterSpacing: ['realtime', 'all'].includes(option),
           }}
         >
           {labels[option] || option}
@@ -69,8 +79,9 @@ const Intervals = styled(UnstyledIntervals)`
   border-top: 1px solid #EFEFEF;
   display: grid;
   grid-auto-flow: column;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-content: center;
+  padding: 0 1rem;
 `
 
 export default Intervals


### PR DESCRIPTION
Add a realtime graph option that displays the `sec` stream in a 10 minute window. I had to change the labels a bit to fit all:

<img width="393" alt="Screenshot 2021-06-23 at 10 15 31" src="https://user-images.githubusercontent.com/1064982/123052934-085de780-d40c-11eb-87dd-9f905bc66a1a.png">


