### PR TITLE
Parse node address

### DIFF
--- a/src/components/Map/Map.stories.tsx
+++ b/src/components/Map/Map.stories.tsx
@@ -30,6 +30,7 @@ const nodes = [
   {
     id: '1',
     title: 'Node 1',
+    address: '0x123abc',
     latitude: 60.16952,
     longitude: 24.93545,
     placeName: 'Helsinki',
@@ -37,6 +38,7 @@ const nodes = [
   {
     id: '2',
     title: 'Node 2',
+    address: '0x456def',
     latitude: 60.14952,
     longitude: 24.92545,
     placeName: 'Helsinki',
@@ -44,6 +46,7 @@ const nodes = [
   {
     id: '3',
     title: 'Node 3',
+    address: '0x789ghi',
     latitude: 52.51667,
     longitude: 13.38333,
     placeName: 'Berlin',
@@ -51,6 +54,7 @@ const nodes = [
   {
     id: '4',
     title: 'Node 4',
+    address: '0x101jkl',
     latitude: 47.49833,
     longitude: 19.04083,
     placeName: 'Budapest',

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -192,7 +192,7 @@ export const ConnectedMap = () => {
       }
 
       if (nodeId) {
-        path += `nodes/${nodeId}`
+        path += `nodes/${encodeURIComponent(nodeId)}`
       }
 
       history.replace(path)

--- a/src/components/MetricGraph.tsx
+++ b/src/components/MetricGraph.tsx
@@ -214,7 +214,13 @@ const MetricGraphLoader = ({ type, metric, id }: Props) => {
       return `streamr.eth/metrics/network/${getStreamFragmentForInterval(interval)}`
     }
 
-    return `${id}/streamr/node/metrics/${getStreamFragmentForInterval(interval)}`
+    if (!id ) {
+      // no idea what typescript wants here
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      throw new (Error as any)('No node selected!')
+    }
+
+    return `${encodeURIComponent(id)}/streamr/node/metrics/${getStreamFragmentForInterval(interval)}`
   }, [type, id, interval])
 
   const loadStream = useCallback(
@@ -236,7 +242,12 @@ const MetricGraphLoader = ({ type, metric, id }: Props) => {
   )
 
   useEffect(() => {
-    loadStream(metricStreamId)
+    try {
+      loadStream(metricStreamId)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(e)
+    }
   }, [loadStream, metricStreamId])
 
   return (

--- a/src/components/Node/TopologyList.tsx
+++ b/src/components/Node/TopologyList.tsx
@@ -19,10 +19,11 @@ const TopologyList = ({ id }: Props) => {
       <NodeList.Node
         nodeId={currentNode.id}
         title={currentNode.title}
+        address={currentNode.address}
         placeName={currentNode.placeName}
         isActive
       >
-        <NodeStats key={currentNode.id} id={currentNode.id} />
+        <NodeStats key={currentNode.id} id={currentNode.address} />
       </NodeList.Node>
     </NodeList>
   ) : null

--- a/src/components/Node/index.tsx
+++ b/src/components/Node/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
@@ -52,7 +52,8 @@ interface ParamTypes {
 }
 
 export default () => {
-  const { nodeId } = useParams<ParamTypes>()
+  const { nodeId: encodedNodeId } = useParams<ParamTypes>()
+  const nodeId = useMemo(() => decodeURIComponent(encodedNodeId), [encodedNodeId])
   const { nodes } = useStore()
 
   if (!nodes || nodes.length < 1) {

--- a/src/components/NodeList/NodeList.stories.tsx
+++ b/src/components/NodeList/NodeList.stories.tsx
@@ -28,6 +28,7 @@ const nodes = [
   {
     id: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',
     title: 'Quick Green Aadvaark',
+    address: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',
     latitude: 60.16952,
     longitude: 24.93545,
     placeName: 'Helsinki',
@@ -35,6 +36,7 @@ const nodes = [
   {
     id: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
     title: 'Warm Fiery Octagon',
+    address: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
     latitude: 60.14952,
     longitude: 24.92545,
     placeName: 'Helsinki',
@@ -42,6 +44,7 @@ const nodes = [
   {
     id: '0xFeaDE0B77130F5468D57037e2a259295bfdD8390',
     title: 'Gold Spicy Fieldmouse',
+    address: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
     latitude: 52.51667,
     longitude: 13.38333,
     placeName: 'Berlin',
@@ -49,6 +52,7 @@ const nodes = [
   {
     id: '0x538a2Fa87E03B280e10C83AA8dD7E5B15B868BD9',
     title: 'Curved Slick Diamond',
+    address: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
     latitude: 47.49833,
     longitude: 19.04083,
     placeName: 'Budapest',
@@ -57,8 +61,19 @@ const nodes = [
 
 export const Basic = () => (
   <NodeList>
-    {nodes.map(({ id, title, placeName }) => (
-      <NodeList.Node key={id} nodeId={id} title={title} placeName={placeName} />
+    {nodes.map(({
+      id,
+      title,
+      address,
+      placeName,
+    }) => (
+      <NodeList.Node
+        key={id}
+        nodeId={id}
+        title={title}
+        address={address}
+        placeName={placeName}
+      />
     ))}
   </NodeList>
 )
@@ -68,8 +83,19 @@ export const WithHeader = () => (
     <NodeList.Header>
       Showing all <strong>{nodes.length}</strong> nodes
     </NodeList.Header>
-    {nodes.map(({ id, title, placeName }) => (
-      <NodeList.Node key={id} nodeId={id} title={title} placeName={placeName} />
+    {nodes.map(({
+      id,
+      title,
+      address,
+      placeName,
+    }) => (
+      <NodeList.Node
+        key={id}
+        nodeId={id}
+        title={title}
+        address={address}
+        placeName={placeName}
+      />
     ))}
   </NodeList>
 )
@@ -79,11 +105,17 @@ export const WithStats = () => {
 
   return (
     <NodeList>
-      {nodes.map(({ id, title, placeName }) => (
+      {nodes.map(({
+        id,
+        title,
+        address,
+        placeName,
+      }) => (
         <NodeList.Node
           key={id}
           nodeId={id}
           title={title}
+          address={address}
           placeName={placeName}
           onClick={() => setActiveNode((prev) => (prev !== id ? id : undefined))}
           isActive={activeNode === id}
@@ -141,11 +173,17 @@ export const WithStatsAndError = () => {
 
   return (
     <NodeList>
-      {nodes.map(({ id, title, placeName }) => (
+      {nodes.map(({
+        id,
+        title,
+        address,
+        placeName,
+      }) => (
         <NodeList.Node
           key={id}
           nodeId={id}
           title={title}
+          address={address}
           placeName={placeName}
           onClick={() => onNodeClick(id !== activeNode ? id : undefined)}
           isActive={activeNode === id}

--- a/src/components/NodeList/NodeListItem.tsx
+++ b/src/components/NodeList/NodeListItem.tsx
@@ -103,6 +103,7 @@ const Address = styled(PlaceName)`
 type Props = {
   nodeId: string
   title: string
+  address: string,
   placeName: string
   onClick?: (id: string) => void
   isActive?: boolean
@@ -112,6 +113,7 @@ type Props = {
 const NodeListItem = ({
   nodeId,
   title,
+  address,
   placeName,
   onClick: onClickProp,
   isActive,
@@ -140,7 +142,7 @@ const NodeListItem = ({
     >
       <TitleRow onClick={onClick}>
         <IconWrapper>
-          <Identicon string={nodeId} size={20} />
+          <Identicon string={address} size={20} />
         </IconWrapper>
         <Name>
           <strong>{title}</strong>
@@ -148,7 +150,7 @@ const NodeListItem = ({
             {transition((style, item) =>
               item ? (
                 <animated.div style={style}>
-                  <Address title={nodeId}>{truncate(nodeId)}</Address>
+                  <Address title={address}>{truncate(address)}</Address>
                 </animated.div>
               ) : (
                 <animated.div style={style}>

--- a/src/components/NodeStats.tsx
+++ b/src/components/NodeStats.tsx
@@ -51,7 +51,7 @@ const NodeStats = ({ id }: Props) => {
 
   useSubscription(
     {
-      stream: `${encodeURIComponent(id)}/streamr/node/metrics/sec`,
+      stream: `${id}/streamr/node/metrics/sec`,
       resend: {
         last: 1,
       },

--- a/src/components/NodeStats.tsx
+++ b/src/components/NodeStats.tsx
@@ -51,7 +51,7 @@ const NodeStats = ({ id }: Props) => {
 
   useSubscription(
     {
-      stream: `${id}/streamr/node/metrics/sec`,
+      stream: `${encodeURIComponent(id)}/streamr/node/metrics/sec`,
       resend: {
         last: 1,
       },

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -52,7 +52,7 @@ const SearchBox = () => {
 
         case 'nodes':
           resetSearchResults()
-          history.push(`/nodes/${id}`)
+          history.push(`/nodes/${encodeURIComponent(id)}`)
           break
 
         case 'locations':

--- a/src/components/Stream/TopologyList.tsx
+++ b/src/components/Stream/TopologyList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useParams, useHistory } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
@@ -16,15 +16,17 @@ interface ParamTypes {
 
 const TopologyList = ({ id }: Props) => {
   const { visibleNodes, stream } = useStore()
-  const { nodeId: activeNodeId } = useParams<ParamTypes>()
+  const { nodeId: encodedNodeId } = useParams<ParamTypes>()
   const history = useHistory()
+
+  const activeNodeId = useMemo(() => decodeURIComponent(encodedNodeId), [encodedNodeId])
 
   const toggleNode = useCallback(
     (nodeId) => {
       let path = `/streams/${encodeURIComponent(id)}`
 
       if (activeNodeId !== nodeId) {
-        path += `/nodes/${nodeId}`
+        path += `/nodes/${encodeURIComponent(nodeId)}`
       }
 
       history.replace(path)
@@ -40,16 +42,22 @@ const TopologyList = ({ id }: Props) => {
         Showing <strong>{visibleNodes.length}</strong> nodes carrying the stream{' '}
         <strong title={id}>{truncate(streamTitle)}</strong>
       </NodeList.Header>
-      {visibleNodes.map(({ id: nodeId, title, placeName }) => (
+      {visibleNodes.map(({
+        id: nodeId,
+        title,
+        address,
+        placeName,
+      }) => (
         <NodeList.Node
           key={nodeId}
           nodeId={nodeId}
           title={title}
+          address={address}
           placeName={placeName}
           onClick={toggleNode}
           isActive={activeNodeId === nodeId}
         >
-          <NodeStats id={nodeId} />
+          <NodeStats id={address} />
         </NodeList.Node>
       ))}
     </NodeList>

--- a/src/components/Stream/index.tsx
+++ b/src/components/Stream/index.tsx
@@ -72,10 +72,11 @@ interface ParamTypes {
 }
 
 export default () => {
-  const { streamId: encodedStreamId, nodeId } = useParams<ParamTypes>()
+  const { streamId: encodedStreamId, nodeId: encodedNodeId } = useParams<ParamTypes>()
   const { nodes } = useStore()
 
   const streamId = useMemo(() => decodeURIComponent(encodedStreamId), [encodedStreamId])
+  const nodeId = useMemo(() => decodeURIComponent(encodedNodeId), [encodedNodeId])
 
   if (!streamId || !nodes || nodes.length < 1) {
     return null

--- a/src/utils/api/tracker.test.js
+++ b/src/utils/api/tracker.test.js
@@ -3,16 +3,52 @@ import * as trackerUtils from 'streamr-client-protocol'
 
 import * as all from './tracker'
 import * as request from '../request'
+import * as mapbox from './mapbox'
 
 jest.mock('bip39')
 jest.mock('streamr-client-protocol')
 jest.mock('../request')
+jest.mock('./mapbox')
+
+const locations = {
+  '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe': {
+    country: 'Poland',
+    city: 'Wroclaw',
+    latitude: 51,
+    longitude: 17,
+  },
+  '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa': {
+    country: 'Spain',
+    city: 'Barcelona',
+    latitude: 41,
+    longitude: 2,
+  },
+  '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990': {
+    country: 'Finland',
+    city: 'Helsinki',
+    latitude: 60,
+    longitude: 24,
+  },
+}
 
 describe('tracker API', () => {
+  beforeAll(() => {
+    // don't show warnigns when console.warn is called
+    jest.spyOn(console, 'warn')
+    // eslint-disable-next-line no-console
+    console.warn.mockImplementation((...args) => {})
+  })
+
   afterEach(() => {
     bip39.entropyToMnemonic.mockClear()
     trackerUtils.Utils.getTrackerRegistryFromContract.mockClear()
     request.get.mockClear()
+    mapbox.getReversedGeocodedLocation.mockClear()
+  })
+
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.warn.mockRestore()
   })
 
   describe('generateMnemonic', () => {
@@ -30,6 +66,153 @@ describe('tracker API', () => {
       expect(entropyToMnemonicMock).toBeCalledWith('123', wordlist)
       expect(result).toStrictEqual('Solid Wooden Table')
       bip39.wordlists = oldWordlist
+    })
+  })
+
+  describe('getAddress', () => {
+    it('strips hash and returns the address', () => {
+      expect(all.getAddress('0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe'))
+        .toBe('0xC983de43c5d22186F1e051c6da419c5a17F19544')
+    })
+
+    it('returns address as is', () => {
+      expect(all.getAddress('0xC983de43c5d22186F1e051c6da419c5a17F19544'))
+        .toBe('0xC983de43c5d22186F1e051c6da419c5a17F19544')
+    })
+  })
+
+  describe('getNodes', () => {
+    it('gets list of nodes from a tracker', async () => {
+      const getMock = jest.fn().mockResolvedValue(locations)
+      request.get.mockImplementation(getMock)
+
+      const entropyToMnemonicMock = jest.fn((id, list) => {
+        const mnemonics = {
+          'C983de43c5d22186F1e051c6da419c5a17F19544': 'strong wooden table',
+          'c3075C2556A1FD30c67530F1ac5ddAE618762CAa': 'fierce concrete spoon',
+          'e61611feb4a4Bd058E2b7f23E53786da530AdA7d': 'mild sunny building',
+        }
+
+        if (!mnemonics[id]) {
+          throw new Error('Mnemonic failed!')
+        }
+
+        return mnemonics[id]
+      })
+      bip39.entropyToMnemonic.mockImplementation(entropyToMnemonicMock)
+
+      const getReversedGeocodedLocationMock = jest.fn(({ latitude, longitude }) => Promise.resolve({
+        region: `${latitude}-${longitude}`,
+      }))
+      mapbox.getReversedGeocodedLocation.mockImplementation(getReversedGeocodedLocationMock)
+
+      const http = 'http://testurl'
+      const result = await all.getNodes(http)
+
+      expect(getMock).toBeCalledWith({
+        url: `${http}/location/`,
+      })
+      expect(result).toStrictEqual([{
+        id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        latitude: 51,
+        longitude: 17,
+        title: 'Strong Wooden Table',
+        placeName: '51-17',
+      }, {
+        id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        latitude: 41,
+        longitude: 2,
+        title: 'Fierce Concrete Spoon',
+        placeName: '41-2',
+      }, {
+        id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        latitude: 60,
+        longitude: 24,
+        title: 'Mild Sunny Building',
+        placeName: '60-24',
+      }])
+    })
+
+    it('uses id as title if mnemonic cannot be generated', async () => {
+      const getMock = jest.fn().mockResolvedValue(locations)
+      request.get.mockImplementation(getMock)
+
+      const entropyToMnemonicMock = jest.fn((id, list) => {
+        throw new Error('Mnemonic failed!')
+      })
+      bip39.entropyToMnemonic.mockImplementation(entropyToMnemonicMock)
+
+      const getReversedGeocodedLocationMock = jest.fn(({ latitude, longitude }) => Promise.resolve({
+        region: `${latitude}-${longitude}`,
+      }))
+      mapbox.getReversedGeocodedLocation.mockImplementation(getReversedGeocodedLocationMock)
+
+      const http = 'http://testurl'
+      const result = await all.getNodes(http)
+
+      expect(getMock).toBeCalledWith({
+        url: `${http}/location/`,
+      })
+      expect(result).toStrictEqual([{
+        id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        latitude: 51,
+        longitude: 17,
+        title: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
+        placeName: '51-17',
+      }, {
+        id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        latitude: 41,
+        longitude: 2,
+        title: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        placeName: '41-2',
+      }, {
+        id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        latitude: 60,
+        longitude: 24,
+        title: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
+        placeName: '60-24',
+      }])
+    })
+
+    it('uses country from response if reverse geocoding fails', async () => {
+      const getMock = jest.fn().mockResolvedValue(locations)
+      request.get.mockImplementation(getMock)
+
+      const entropyToMnemonicMock = jest.fn((id, list) => {
+        throw new Error('Mnemonic failed!')
+      })
+      bip39.entropyToMnemonic.mockImplementation(entropyToMnemonicMock)
+
+      const getReversedGeocodedLocationMock = jest.fn(({ latitude, longitude }) => Promise.resolve({
+        region: undefined,
+      }))
+      mapbox.getReversedGeocodedLocation.mockImplementation(getReversedGeocodedLocationMock)
+
+      const http = 'http://testurl'
+      const result = await all.getNodes(http)
+
+      expect(getMock).toBeCalledWith({
+        url: `${http}/location/`,
+      })
+      expect(result).toStrictEqual([{
+        id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        latitude: 51,
+        longitude: 17,
+        title: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
+        placeName: 'Poland',
+      }, {
+        id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        latitude: 41,
+        longitude: 2,
+        title: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        placeName: 'Spain',
+      }, {
+        id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        latitude: 60,
+        longitude: 24,
+        title: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
+        placeName: 'Finland',
+      }])
     })
   })
 

--- a/src/utils/api/tracker.test.js
+++ b/src/utils/api/tracker.test.js
@@ -114,18 +114,21 @@ describe('tracker API', () => {
       })
       expect(result).toStrictEqual([{
         id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        address: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
         latitude: 51,
         longitude: 17,
         title: 'Strong Wooden Table',
         placeName: '51-17',
       }, {
         id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        address: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
         latitude: 41,
         longitude: 2,
         title: 'Fierce Concrete Spoon',
         placeName: '41-2',
       }, {
         id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        address: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
         latitude: 60,
         longitude: 24,
         title: 'Mild Sunny Building',
@@ -133,7 +136,7 @@ describe('tracker API', () => {
       }])
     })
 
-    it('uses id as title if mnemonic cannot be generated', async () => {
+    it('uses address as title if mnemonic cannot be generated', async () => {
       const getMock = jest.fn().mockResolvedValue(locations)
       request.get.mockImplementation(getMock)
 
@@ -155,18 +158,21 @@ describe('tracker API', () => {
       })
       expect(result).toStrictEqual([{
         id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        address: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
         latitude: 51,
         longitude: 17,
         title: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
         placeName: '51-17',
       }, {
         id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        address: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
         latitude: 41,
         longitude: 2,
         title: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
         placeName: '41-2',
       }, {
         id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        address: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
         latitude: 60,
         longitude: 24,
         title: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
@@ -196,18 +202,21 @@ describe('tracker API', () => {
       })
       expect(result).toStrictEqual([{
         id: '0xC983de43c5d22186F1e051c6da419c5a17F19544#4caa44ec-c26d-4cb2-9056-c54e60eceafe',
+        address: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
         latitude: 51,
         longitude: 17,
         title: '0xC983de43c5d22186F1e051c6da419c5a17F19544',
         placeName: 'Poland',
       }, {
         id: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
+        address: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
         latitude: 41,
         longitude: 2,
         title: '0xc3075C2556A1FD30c67530F1ac5ddAE618762CAa',
         placeName: 'Spain',
       }, {
         id: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d#490eb3e7-33c2-45e4-9ab2-b09de1e29990',
+        address: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',
         latitude: 60,
         longitude: 24,
         title: '0xe61611feb4a4Bd058E2b7f23E53786da530AdA7d',

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -51,6 +51,7 @@ export const getTrackerForStream = async (options: { id: string; partition?: num
 export type Node = {
   id: string
   title: string
+  address: string,
   latitude: number
   longitude: number
   placeName: string
@@ -97,10 +98,11 @@ export const getNodes = async (url: string): Promise<Node[]> => {
     Object.keys(result || []).map(async (id: string) => {
       const { latitude, longitude, country } = result[id] || {}
       const { region } = await getReversedGeocodedLocation({ latitude, longitude })
-      let title = getAddress(id)
+      const address = getAddress(id)
+      let title
 
       try {
-        title = generateMnemonic(title)
+        title = generateMnemonic(address)
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(e)
@@ -110,7 +112,8 @@ export const getNodes = async (url: string): Promise<Node[]> => {
         id,
         latitude,
         longitude,
-        title,
+        address,
+        title: title || address,
         placeName: region || country,
       }
     }),

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -71,6 +71,16 @@ export const generateMnemonic = (id: string) =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 
+export const getAddress = (id: string) => {
+  const hashPos = id.indexOf('#')
+
+  if (hashPos < 0) {
+    return id
+  }
+
+  return id.slice(0, hashPos)
+}
+
 export const getNodes = async (url: string): Promise<Node[]> => {
   let result: NodeResultList = {}
 
@@ -87,12 +97,20 @@ export const getNodes = async (url: string): Promise<Node[]> => {
     Object.keys(result || []).map(async (id: string) => {
       const { latitude, longitude, country } = result[id] || {}
       const { region } = await getReversedGeocodedLocation({ latitude, longitude })
+      let title = getAddress(id)
+
+      try {
+        title = generateMnemonic(title)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(e)
+      }
 
       return {
         id,
         latitude,
         longitude,
-        title: generateMnemonic(id),
+        title,
         placeName: region || country,
       }
     }),


### PR DESCRIPTION
There was a change in the tracker API that added a randomly generated session id as part of the node id to disambiguate nodes running with the same private key. The format is `[address]#[sessionId]` (eg. `0xE698e1aeC4F099c50B9408f23AeaF3f0892147a1#3c6bbccc-4aca-4a82-aea5-59ea7ae1761e`).

We have to parse the address from the incoming `id` and use URL encoding/decoding whenever referencing this in links. However, node specific metric streams will still be referenced with the address, not id.

