### PR TITLE
[FRONT-448] Implement Network selector dropdown

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import { ConnectedMap } from '../components/Map'
 import SearchBox from '../components/SearchBox'
 import Stream from '../components/Stream'
 import Network from '../components/Network'
+import NetworkSelector from '../components/NetworkSelector'
 import Debug from '../components/Debug'
 import UnstyledLoadingIndicator from '../components/LoadingIndicator'
 import Layout from '../components/Layout'
@@ -87,6 +88,7 @@ const App = () => (
                 <TrackerLoader />
                 <SearchTextResetter />
                 <Debug />
+                <NetworkSelector />
                 <SearchBox />
                 <Switch>
                   <Route exact path="/streams/:streamId/nodes/:nodeId" component={Stream} />

--- a/src/components/Debug/index.tsx
+++ b/src/components/Debug/index.tsx
@@ -1,13 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { useHistory } from 'react-router-dom'
+import React from 'react'
 import styled from 'styled-components/macro'
 import JsonView from 'react-pretty-json'
 
 import { useAllPending } from '../../contexts/Pending'
 import { useStore } from '../../contexts/Store'
-import envs from '../../utils/envs'
 import {
-  MONO, SANS, MEDIUM, MD,
+  MONO, SANS, MD,
 } from '../../utils/styled'
 import { isLocalStorageAvailable } from '../../utils/storage'
 
@@ -25,23 +23,15 @@ export function setDebugMode(value: boolean) {
   storage.setItem(APP_DEBUG_MODE_KEY, JSON.stringify(value))
 }
 
-const openTheme = {
-  background: 'rgba(0, 0, 0, 0.3)',
-}
-
-const closeTheme = {
-  background: 'transparent',
-}
-
 const DebugContainer = styled.div`
   position: fixed;
-  top: 24px;
-  right: 24px;
+  bottom: 218px;
+  right: 32px;
   border-radius: 4px;
   color: white;
   font-family: ${SANS};
   font-size: 12px;
-  background-color: ${({ theme }) => theme.background};
+  background-color: rgba(0, 0, 0, 0.3);
   padding: 8px;
 
   button {
@@ -100,105 +90,29 @@ const Variables = styled.pre`
   }
 `
 
-const EnvSelect = styled.label`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: 8px;
-
-  span {
-    flex-grow: 1;
-  }
-
-  select {
-    flex-grow: 1;
-    margin-left: 16px;
-    height: 20px;
-  }
-
-  button {
-    margin-left: 8px;
-    font-size: 12px;
-  }
-`
-
-const OpenView = styled.div`
-  span {
-    user-select: none;
-    pointer-events: none;
-    text-shadow: 1px 1px 5px rgba(0, 0, 0, 0.5);
-
-    strong {
-      text-transform: uppercase;
-      font-weight: ${MEDIUM};
-      color: #fafad2;
-    }
-  }
-
-  button {
-    margin-left: 8px;
-  }
-`
+const isDebugEnabled = getDebugMode()
 
 const Debug = () => {
   const { pending } = useAllPending()
-  const { env: selectedEnv, store } = useStore()
-  const history = useHistory()
-  const [open, setOpen] = useState<boolean>(getDebugMode())
+  const { store } = useStore()
 
-  const toggleDebugMode = useCallback(() => {
-    setOpen((wasOpen) => !wasOpen)
-  }, [])
-
-  useEffect(() => {
-    setDebugMode(open)
-  }, [open])
-
-  const changeEnv = useCallback((env: string) => {
-    history.push(`/?network=${env}`)
-  }, [history])
+  // Hide debug view if not enabled in local storage
+  if (!isDebugEnabled) {
+    return null
+  }
 
   return (
-    <DebugContainer theme={open ? openTheme : closeTheme}>
-      {!open && (
-        <OpenView>
-          <span>
-            using <strong>{selectedEnv}</strong> data
-          </span>
-          <button type="button" onClick={toggleDebugMode}>
-            &#8505;
-          </button>
-        </OpenView>
-      )}
-      {!!open && (
-        <Wrapper>
-          <EnvSelect htmlFor="env">
-            <span>Selected env:</span>
-            <select
-              name="env"
-              value={selectedEnv}
-              onChange={(e) => changeEnv(e.currentTarget.value)}
-            >
-              {Object.keys(envs).map((env) => (
-                <option key={env} value={env}>
-                  {env}
-                </option>
-              ))}
-            </select>
-            <button type="button" onClick={toggleDebugMode}>
-              &#x2715;
-            </button>
-          </EnvSelect>
-          <Variables>
-            <JsonView
-              json={{
-                pending,
-                store,
-              }}
-            />
-          </Variables>
-        </Wrapper>
-      )}
+    <DebugContainer>
+      <Wrapper>
+        <Variables>
+          <JsonView
+            json={{
+              pending,
+              store,
+            }}
+          />
+        </Variables>
+      </Wrapper>
     </DebugContainer>
   )
 }

--- a/src/components/Map/NavigationControl.tsx
+++ b/src/components/Map/NavigationControl.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/macro'
 
-import Tooltip from './Tooltip'
+import Tooltip from '../Tooltip'
 import { SM } from '../../utils/styled'
 
 const Button = styled.button`

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useCallback } from 'react'
+import { useHistory } from 'react-router-dom'
+import styled from 'styled-components/macro'
+
+import envs from '../../utils/envs'
+import Tooltip from '../Tooltip'
+import { useStore } from '../../contexts/Store'
+import { SANS } from '../../utils/styled'
+
+const GlobeIcon = () => (
+  <svg width="18" height="18" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M7.934 16.73a8 8 0 118.995-8.996M7.073 16.566C5.99 14.98 5.267 12.095 5.267 8.8c0-3.294.724-6.178 1.806-7.766M1.018 8.267h6.916M2.6 4h12.8M1.924 12.534h3.673M10.928 1.034a12.105 12.105 0 011.642 5.103"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const TickIcon = () => (
+  <svg width="12" height="12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M2.094 7.562l2.38 2.57 5.658-5.657"
+      stroke="#525252"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const themes: Record<string, Object> = {
+  mainnet: {
+    color: '#0EAC1B',
+  },
+  testnet: {
+    color: '#FF7575',
+  },
+  default: {
+    color: '#EFEFEF',
+  },
+}
+
+const NetworkIndicator = styled.div`
+  border-radius: 50%;
+  width: 8px;
+  height: 8px;
+  background-color: ${({ theme }) => theme.color};
+`
+
+const Button = styled.button`
+  appearance: none;
+  border: 0;
+  background: none;
+  outline: none;
+  background-color: #FFFFFF;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  width: 40px;
+  height: 40px;
+  position: relative;
+  color: #A3A3A3;
+  transition: 300ms color ease-in-out;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+
+  svg {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  ${NetworkIndicator} {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) translate(4px, 4px);
+  }
+
+  :hover {
+    color: #323232;
+  }
+`
+
+const NetworkList = styled.div`
+  background-color: #FFFFFF;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  position: absolute;
+  right: 0;
+  top: 48px;
+  padding: 4px 14px;
+`
+
+const NetworkName = styled.div`
+  font-family: ${SANS};
+  font-size: 14px;
+`
+
+const NetworkItem = styled.button`
+  height: 28px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  appearance: none;
+  border: 0;
+  background: none;
+  outline: none;
+  text-align: left;
+  padding: 0;
+  margin: 0;
+
+  ${NetworkName} {
+    flex: 1;
+    margin-left: 12px;
+    min-width: 64px;
+  }
+`
+
+type Props = {}
+
+const UnstyledNetworkSelector = (props: Props) => {
+  const { env: selectedEnv } = useStore()
+  const [open, setOpen] = useState<boolean>(false)
+  const history = useHistory()
+
+  const toggleOpen = useCallback(() => {
+    setOpen((wasOpen) => !wasOpen)
+  }, [])
+
+  const changeEnv = useCallback((env: string) => {
+    history.push(`/?network=${env}`)
+    setOpen(false)
+  }, [history])
+
+  return (
+    <div {...props}>
+      <Tooltip value="Network selector">
+        <Button type="button" onClick={toggleOpen}>
+          <GlobeIcon />
+          <NetworkIndicator
+            theme={(!!selectedEnv && !!themes[selectedEnv]) ? themes[selectedEnv] : themes.default}
+          />
+        </Button>
+      </Tooltip>
+      {!!open && (
+        <NetworkList>
+            {Object.keys(envs).map((env) => (
+              <NetworkItem key={env} type="button" onClick={() => changeEnv(env)}>
+                <NetworkIndicator
+                  theme={themes[env] ? themes[env] : themes.default}
+                />
+                <NetworkName>
+                  {env.charAt(0).toUpperCase() + env.slice(1)}
+                </NetworkName>
+                <div>
+                  {(env === selectedEnv) && (
+                    <TickIcon />
+                  )}
+                </div>
+              </NetworkItem>
+            ))}
+        </NetworkList>
+      )}
+    </div>
+  )
+}
+
+const NetworkSelector = styled(UnstyledNetworkSelector)`
+  position: fixed;
+  top: 32px;
+  right: 32px;
+`
+
+export default NetworkSelector

--- a/src/components/SearchBox/SearchInput.tsx
+++ b/src/components/SearchBox/SearchInput.tsx
@@ -15,7 +15,7 @@ const Inner = styled.div`
 
 const IconButton = styled.button`
   appearance: none;
-  border: none;
+  border: 0;
   background: none;
   outline: none;
   margin: 0;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 
-import { SANS } from '../../utils/styled'
+import { SANS } from '../utils/styled'
 
 type RootProps = {
   readonly tooltip: string

--- a/src/utils/config.test.js
+++ b/src/utils/config.test.js
@@ -10,12 +10,12 @@ describe('config', () => {
   let defaultEnv
 
   beforeEach(() => {
-    defaultEnv = process.env.DEFAULT_ENV
+    defaultEnv = process.env.REACT_APP_DEFAULT_ENV
     global.localStorage.clear()
   })
 
   afterEach(() => {
-    process.env.DEFAULT_ENV = defaultEnv
+    process.env.REACT_APP_DEFAULT_ENV = defaultEnv
   })
 
   afterAll(() => {
@@ -24,13 +24,13 @@ describe('config', () => {
 
   describe('getEnvironment', () => {
     it('returns default environment if localstorage not set', () => {
-      process.env.DEFAULT_ENV = 'staging'
+      process.env.REACT_APP_DEFAULT_ENV = 'staging'
 
       expect(getEnvironment()).toStrictEqual('staging')
     })
 
     it('returns value from localstorage', () => {
-      process.env.DEFAULT_ENV = 'staging'
+      process.env.REACT_APP_DEFAULT_ENV = 'staging'
       global.localStorage.setItem(APP_ENV_KEY, JSON.stringify('someOtherValue'))
 
       expect(getEnvironment()).toStrictEqual('someOtherValue')
@@ -47,26 +47,26 @@ describe('config', () => {
 
   describe('getConfig', () => {
     it('gets default env config (no env flag)', () => {
-      process.env.DEFAULT_ENV = ''
+      process.env.REACT_APP_DEFAULT_ENV = ''
 
       expect(getConfig()).toStrictEqual('local')
     })
 
     it('gets default env config (env flag)', () => {
-      process.env.DEFAULT_ENV = 'production'
+      process.env.REACT_APP_DEFAULT_ENV = 'production'
 
       expect(getConfig()).toStrictEqual('production')
     })
 
     it('gets default env config (localstorage)', () => {
-      process.env.DEFAULT_ENV = 'production'
+      process.env.REACT_APP_DEFAULT_ENV = 'production'
       setEnvironment('staging')
 
       expect(getConfig()).toStrictEqual('staging')
     })
 
     it('returns the given env', () => {
-      process.env.DEFAULT_ENV = 'production'
+      process.env.REACT_APP_DEFAULT_ENV = 'production'
       setEnvironment('staging')
 
       expect(getConfig({ env: 'local' })).toStrictEqual('local')

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,7 +6,7 @@ const storage = isLocalStorageAvailable() ? window.localStorage : null
 
 export function getEnvironment() {
   return (
-    (!!storage && JSON.parse(storage.getItem(APP_ENV_KEY) || 'false')) || process.env.DEFAULT_ENV
+    (!!storage && JSON.parse(storage.getItem(APP_ENV_KEY) || 'false')) || process.env.REACT_APP_DEFAULT_ENV
   )
 }
 

--- a/src/utils/envs.ts
+++ b/src/utils/envs.ts
@@ -20,7 +20,28 @@ export type EnvConfig = {
 type Envs = Record<string, EnvConfig>
 
 const envs: Envs = {
-  'mock-api': {
+  mainnet: {
+    tracker: {
+      source: 'contract',
+      contractAddress: '0xb21df4018dee577cd33f5b99f269ea7b23b8e6eb',
+      jsonRpcProvider: 'https://mainnet.infura.io/v3/17c3985baecb4c4d94a1edc2c4d23206',
+    },
+    streamr: {
+      http: 'https://streamr.network/api/v1',
+      ws: 'wss://streamr.network/api/v1/ws',
+    },
+  },
+  testnet: {
+    tracker: {
+      source: 'http',
+      http: 'https://testnet1.streamr.network:30300',
+    },
+    streamr: {
+      http: 'https://testnet1.streamr.network:7001',
+      ws: 'wss://testnet1.streamr.network:7001',
+    },
+  },
+  mockApi: {
     tracker: {
       source: 'http',
       http: process.env.REACT_APP_MOCK_API_URL || '',
@@ -39,17 +60,6 @@ const envs: Envs = {
     streamr: {
       http: process.env.REACT_APP_STREAMR_API_URL || '',
       ws: process.env.REACT_APP_STREAMR_WS_URL || '',
-    },
-  },
-  production: {
-    tracker: {
-      source: 'contract',
-      contractAddress: '0xb21df4018dee577cd33f5b99f269ea7b23b8e6eb',
-      jsonRpcProvider: 'https://mainnet.infura.io/v3/17c3985baecb4c4d94a1edc2c4d23206',
-    },
-    streamr: {
-      http: 'https://streamr.network/api/v1',
-      ws: 'wss://streamr.network/api/v1/ws',
     },
   },
 }


### PR DESCRIPTION
Add network selector to upper right corner. Debug view is now hidden unless `network-eplorer.debug` variable is set in local storage.

Use `http://[explorer url]/?network=production` to link directly to a network

