### PR TITLE
[FRONT-475] Improve network selector closing

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import { SANS } from '../utils/styled'
 
 type RootProps = {
-  readonly tooltip: string
+  readonly tooltip: string | undefined
 }
 
 const Root = styled.div<RootProps>`
@@ -45,7 +45,7 @@ const Root = styled.div<RootProps>`
 `
 
 type Props = {
-  value: string
+  value: string | undefined
   children: React.ReactNode
 }
 


### PR DESCRIPTION
> The only way to close it is to click the icon again. Not good UX, we need to give users multiple common paths to do this
>
> * clicking on the map background
> * hitting the esc key on keyboard
> * clicking the selector icon

Improve closing of the network selector. Also hide tooltip while dropdown is open.