### PR TITLE
[FRONT-520] Update active node when nodes change

### DIFF
--- a/src/contexts/Store.tsx
+++ b/src/contexts/Store.tsx
@@ -476,9 +476,12 @@ function useStoreContext() {
     [topology, fetchedLocations],
   )
 
-  const activeNode = useMemo(() => denormalize(activeNodeId, nodeSchema, entitiesRef.current), [
-    activeNodeId,
-  ])
+  const activeNode = useMemo(() => denormalize(activeNodeId, nodeSchema, entitiesRef.current),
+    // Update active node also when nodes change so that we will update
+    // activeNode after activeNodeId was set but nodes were not loaded yet.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeNodeId, nodes],
+  )
 
   const activeLocation = useMemo(
     () => denormalize(activeLocationId, searchResultSchema, entitiesRef.current),


### PR DESCRIPTION
Active node effect was not visible on map when reloaded page with nodeId in URL. Now it is fixed.