### PR TITLE
Allow to select random http tracker

### DIFF
--- a/src/utils/api/tracker.test.js
+++ b/src/utils/api/tracker.test.js
@@ -190,11 +190,38 @@ describe('tracker API', () => {
       trackerSpy.mockRestore()
     })
 
-    it('gets testnet address', async () => {
+    it('gets random testnet address', async () => {
+      const trackerHttps = [
+        'http://streamr.network/:30301',
+        'http://streamr.network/:30302',
+        'http://streamr.network/:30303',
+      ]
       const configSpy = jest.spyOn(config, 'default').mockReturnValue({
         tracker: {
           source: 'http',
-          http: 'http://streamr.network/:30301',
+          strategy: 'random',
+          http: trackerHttps,
+        },
+      })
+
+      const result = await all.getTrackers()
+
+      expect(result.length).toBe(1)
+      expect(trackerHttps.includes(result[0])).toBe(true)
+
+      configSpy.mockRestore()
+    })
+
+    it('gets all testnet addresses', async () => {
+      const configSpy = jest.spyOn(config, 'default').mockReturnValue({
+        tracker: {
+          source: 'http',
+          strategy: 'all',
+          http: [
+            'http://streamr.network/:30301',
+            'http://streamr.network/:30302',
+            'http://streamr.network/:30303',
+          ],
         },
       })
 
@@ -202,6 +229,8 @@ describe('tracker API', () => {
 
       expect(result).toStrictEqual([
         'http://streamr.network/:30301',
+        'http://streamr.network/:30302',
+        'http://streamr.network/:30303',
       ])
 
       configSpy.mockRestore()
@@ -209,7 +238,7 @@ describe('tracker API', () => {
   })
 
   describe('getTracker', () => {
-    it('gets tracker with id', async () => {
+    it('gets tracker with id from contract', async () => {
       const configSpy = jest.spyOn(config, 'default').mockReturnValue({
         tracker: {
           source: 'contract',
@@ -248,7 +277,7 @@ describe('tracker API', () => {
       trackerSpy.mockRestore()
     })
 
-    it('gets tracker with id and partition', async () => {
+    it('gets tracker with id and partition from contract', async () => {
       const configSpy = jest.spyOn(config, 'default').mockReturnValue({
         tracker: {
           source: 'contract',
@@ -270,6 +299,27 @@ describe('tracker API', () => {
 
       configSpy.mockRestore()
       trackerSpy.mockRestore()
+    })
+
+    it('gets tracker with id from testnet', async () => {
+      const trackerHttps = [
+        'http://streamr.network/:30301',
+        'http://streamr.network/:30302',
+        'http://streamr.network/:30303',
+      ]
+      const configSpy = jest.spyOn(config, 'default').mockReturnValue({
+        tracker: {
+          source: 'http',
+          strategy: 'all',
+          http: trackerHttps,
+        },
+      })
+
+      const result = await all.getTrackerForStream({ id: 'mystream', partition: 3 })
+
+      expect(result.includes(result[0])).toBe(true)
+
+      configSpy.mockRestore()
     })
   })
 

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -1,5 +1,6 @@
 import { Utils } from 'streamr-client-protocol'
 import { GraphLink } from '@streamr/quick-dijkstra-wasm'
+import sample from 'lodash/sample'
 
 import { Location } from './mapbox'
 
@@ -10,13 +11,25 @@ const getTrackerRegistry = async () => {
   const { tracker } = getConfig()
 
   if (tracker.source === 'http') {
+    const { strategy, http } = tracker
+
     return {
-      getAllTrackers: () => [{
-        http: tracker.http,
-      }],
-      getTracker: () => ({
-        http: tracker.http,
-      }),
+      getAllTrackers: () => {
+        if (strategy === 'all') {
+          return http.map((url) => ({
+            http: url,
+          }))
+        }
+
+        return [{
+          http: sample(http),
+        }]
+      },
+      getTracker: () => {
+        return {
+          http: sample(http),
+        }
+      },
     }
   }
 

--- a/src/utils/envs.ts
+++ b/src/utils/envs.ts
@@ -6,7 +6,8 @@ type TrackerConfig =
   }
   | {
     source: 'http'
-    http: string
+    strategy?: 'random' | 'all'
+    http: string[]
   }
 
 export type EnvConfig = {
@@ -34,7 +35,10 @@ const envs: Envs = {
   testnet: {
     tracker: {
       source: 'http',
-      http: 'https://testnet1.streamr.network:30300',
+      strategy: 'random',
+      http: [
+        'https://testnet1.streamr.network:30300',
+      ],
     },
     streamr: {
       http: 'https://streamr.network/api/v1',


### PR DESCRIPTION
Prepare for [FRONT-535](https://linear.app/streamr/issue/FRONT-535/update-ne-to-randomly-select-a-node), allow selecting a testnet HTTP tracker at random (or all).