### PR TITLE
Load node connections only when needed

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -30,7 +30,6 @@ type Props = {
   setViewport: React.Dispatch<React.SetStateAction<ViewportProps>>
   onNodeClick?: (v: string) => void
   onMapClick?: () => void
-  canShowConnections?: boolean,
   showConnections?: boolean
 } & NavigationControlProps
 
@@ -75,7 +74,6 @@ export const Map = ({
   onZoomOut,
   onZoomReset,
   onToggleConnections,
-  canShowConnections = false,
   showConnections = false,
 }: Props) => {
   const mapRef = useRef<MapRef>(null)
@@ -175,9 +173,7 @@ export const Map = ({
         inertia: INERTIA,
       }}
     >
-      {!!canShowConnections && (
-        <ConnectionLayer topology={topology} nodes={nodes} visible={!!showConnections} />
-      )}
+      <ConnectionLayer topology={topology} nodes={nodes} visible={!!showConnections} />
       <MarkerLayer
         nodes={nodes}
         sourceId={NODE_SOURCE_ID}
@@ -187,7 +183,7 @@ export const Map = ({
         onZoomIn={onZoomIn}
         onZoomOut={onZoomOut}
         onZoomReset={onZoomReset}
-        onToggleConnections={canShowConnections ? onToggleConnections : undefined}
+        onToggleConnections={onToggleConnections}
         ref={navRef}
       />
     </ReactMapGL>
@@ -326,8 +322,7 @@ export const ConnectedMap = () => {
         onZoomIn={zoomIn}
         onZoomOut={zoomOut}
         onZoomReset={reset}
-        canShowConnections={!!streamId}
-        showConnections={showConnections === 'auto' || showConnections === 'always'}
+        showConnections={(showConnections === 'auto' && !!streamId) || showConnections === 'always'}
         onToggleConnections={toggleShowConnections}
       />
     </MapContainer>

--- a/src/components/Network/index.tsx
+++ b/src/components/Network/index.tsx
@@ -7,15 +7,20 @@ import TopologyList from './TopologyList'
 import envs from '../../utils/envs'
 
 const NodeConnectionsLoader = () => {
+  const { showConnections: connectionMode } = useStore()
   const { loadTopology, resetTopology } = useController()
 
+  const showConnections = !!(connectionMode === 'always')
+
   useEffect(() => {
-    loadTopology()
+    loadTopology({
+      showConnections,
+    })
 
     return () => {
       resetTopology()
     }
-  }, [loadTopology, resetTopology])
+  }, [loadTopology, resetTopology, showConnections])
 
   return null
 }

--- a/src/contexts/Controller.test.tsx
+++ b/src/contexts/Controller.test.tsx
@@ -32,7 +32,7 @@ describe('Controller', () => {
   })
 
   describe('loadTrackers', () => {
-    it('sets trackers and nodes', async () => {
+    it('loads trackers and nodes', async () => {
       let store
       let controller
 
@@ -74,15 +74,16 @@ describe('Controller', () => {
       jest.spyOn(trackerApi, 'getTrackers').mockImplementation(getTrackersMock)
       jest.spyOn(trackerApi, 'getNodes').mockImplementation(getNodesMock)
 
+      let result
       await act(async () => {
-        await controller.loadTrackers()
+        result = await controller.loadTrackers()
       })
 
-      expect(store.trackers).toStrictEqual([
+      expect(result.trackers).toStrictEqual([
         'tracker1',
         'tracker2',
       ])
-      expect(store.nodes).toStrictEqual([{
+      expect(result.nodes).toStrictEqual([{
         id: '1',
       }, {
         id: '2',


### PR DESCRIPTION
This could probably use some refinement still but putting it out there... Improves map view by restoring the connections toggle, it calls the `/node-connections` endpoint only when necessary.