### PR TITLE
[FRONT-543] Use GeoJSON layer for node markers

### DIFF
--- a/src/components/Map/MarkerLayer.tsx
+++ b/src/components/Map/MarkerLayer.tsx
@@ -4,9 +4,11 @@ import { Node } from '../../utils/api/tracker'
 
 type Props = {
   nodes: Node[]
+  sourceId: string
+  layerId: string
 }
 
-const MarkerLayer = ({ nodes }: Props) => {
+const MarkerLayer = ({ nodes, sourceId, layerId }: Props) => {
   const geoJson: GeoJSON.FeatureCollection<GeoJSON.Geometry> = useMemo(() => {
     return {
       type: 'FeatureCollection',
@@ -27,9 +29,9 @@ const MarkerLayer = ({ nodes }: Props) => {
   // promoteId for Source is needed so that we can use string ids for Features.
   // We need Feature ids for using feature states to control styling dynamically.
   return (
-    <Source id="node-source" type="geojson" data={geoJson} promoteId="id">
+    <Source id={sourceId} type="geojson" data={geoJson} promoteId="id">
       <Layer
-        id="node-layer"
+        id={layerId}
         type="circle"
         paint={{
           'circle-radius': [

--- a/src/components/Map/MarkerLayer.tsx
+++ b/src/components/Map/MarkerLayer.tsx
@@ -1,26 +1,60 @@
-import React from 'react'
-import { Marker } from 'react-map-gl'
-import { NodeMarker } from './Markers'
+import React, { useMemo } from 'react'
+import { Source, Layer } from 'react-map-gl'
 import { Node } from '../../utils/api/tracker'
 
 type Props = {
   nodes: Node[]
-  activeNode?: string
-  onNodeClick?: (v: string) => void
 }
 
-const MarkerLayer = ({ nodes, activeNode, onNodeClick }: Props) => (
-  <>
-    {nodes.map(({ id, location }) => (
-      <Marker key={`node-${id}`} latitude={location.latitude} longitude={location.longitude}>
-        <NodeMarker
-          id={id}
-          isActive={activeNode === id}
-          onClick={() => onNodeClick && onNodeClick(id)}
-        />
-      </Marker>
-    ))}
-  </>
-)
+const MarkerLayer = ({ nodes }: Props) => {
+  const geoJson: GeoJSON.FeatureCollection<GeoJSON.Geometry> = useMemo(() => {
+    return {
+      type: 'FeatureCollection',
+      features: nodes.map((node) => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [node.location.longitude, node.location.latitude],
+        },
+        properties: {
+          id: node.id,
+          title: node.title,
+        },
+      })),
+    }
+  }, [nodes])
+
+  // promoteId for Source is needed so that we can use string ids for Features.
+  // We need Feature ids for using feature states to control styling dynamically.
+  return (
+    <Source id="node-source" type="geojson" data={geoJson} promoteId="id">
+      <Layer
+        id="node-layer"
+        type="circle"
+        paint={{
+          'circle-radius': [
+            'case',
+            ['boolean', ['feature-state', 'hover'], false],
+            6,
+            4,
+          ],
+          'circle-color': [
+            'case',
+            ['boolean', ['feature-state', 'active'], false],
+            '#ffffff',
+            '#0324ff',
+          ],
+          'circle-stroke-color': '#0324ff',
+          'circle-stroke-width': [
+            'case',
+            ['boolean', ['feature-state', 'active'], false],
+            8,
+            0,
+          ],
+        }}
+      />
+    </Source>
+  )
+}
 
 export default MarkerLayer

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -52,6 +52,9 @@ const defaultViewport = {
 // react-map-gl documentation: The value specifies after how long the operation comes to a stop, in milliseconds
 const INERTIA = 300
 
+const NODE_SOURCE_ID = 'node-source'
+const NODE_LAYER_ID = 'node-layer'
+
 function getCursor({ isHovering, isDragging }: { isHovering: boolean; isDragging: boolean }) {
   if (isDragging) {
     return 'all-scroll'
@@ -83,9 +86,9 @@ export const Map = ({
   const setNodeFeatureState = useCallback((id: string, state) => {
     const map = mapRef.current?.getMap()
 
-    if (map) {
+    if (map && map.loaded()) {
       map.setFeatureState({
-        source: 'node-source',
+        source: NODE_SOURCE_ID,
         id,
       }, {
         ...state,
@@ -120,7 +123,7 @@ export const Map = ({
       onViewportChange={setViewport}
       getCursor={getCursor}
       ref={mapRef}
-      interactiveLayerIds={['node-layer']}
+      interactiveLayerIds={[NODE_LAYER_ID]}
       onClick={(e) => {
         if (!navRef.current!.contains(e.target)) {
           // Did we click on a node or just the background map layer?
@@ -174,6 +177,8 @@ export const Map = ({
       )}
       <MarkerLayer
         nodes={nodes}
+        sourceId={NODE_SOURCE_ID}
+        layerId={NODE_LAYER_ID}
       />
       <NavigationControl
         onZoomIn={onZoomIn}


### PR DESCRIPTION
This PR uses a GeoJSON circle layer to draw node markers on map. Rendering perfomance is greatly improved this way. We'll need to use Mapbox feature states to control hover and active styles for nodes.

Note that we'll lose smooth CSS transitions for hover and active states. Mapbox should support transitions for style changes but I could not make it work. Let's see later if we can add animations.