### PR TITLE
Use for loops instead of .reduce for node mappings

### DIFF
--- a/src/contexts/Controller.tsx
+++ b/src/contexts/Controller.tsx
@@ -113,7 +113,7 @@ function useControllerContext() {
       wrapTopology(async () => {
         const { streamId } = options || {}
 
-        let newTopology
+        let newTopology: trackerApi.Topology = {}
         let didChange = false
 
         if (streamId) {
@@ -135,19 +135,15 @@ function useControllerContext() {
             await loadTrackers()
           }
         } else {
-          const nextNodes = await loadTrackers()
+          const nextNodes = await loadTrackers() || []
 
           if (!isMounted()) {
             return
           }
 
-          newTopology = (nextNodes || []).reduce(
-            (topology: trackerApi.Topology, { id }: trackerApi.Node) => ({
-              ...topology,
-              [id]: {},
-            }),
-            {},
-          )
+          for (let i = 0; i < nextNodes.length; ++i) {
+            newTopology[nextNodes[i].id] = {}
+          }
         }
 
         setTopology({

--- a/src/contexts/Store.tsx
+++ b/src/contexts/Store.tsx
@@ -162,21 +162,20 @@ const reducer = (state: Store, action: Action) => {
 
       // filter out locations that have been fetched already
       if (entities.locations) {
-        entities.locations = Object.keys(entities.locations)
-          .reduce((result, nodeId) => {
-            const { isReverseGeoCoded } = state.entities.locations[nodeId] || {}
+        const keys = Object.keys(entities.locations)
 
-            if (isReverseGeoCoded) {
-              return result
+        const nextLocations: Record<string, mapboxApi.Location> = {}
+        for (let i = 0; i < keys.length; ++i) {
+          const { isReverseGeoCoded } = state.entities.locations[keys[i]] || {}
+
+          if (!isReverseGeoCoded) {
+            nextLocations[keys[i]] = {
+              ...entities.locations[keys[i]],
             }
+          }
+        }
 
-            return ({
-              ...result,
-              [nodeId]: {
-                ...entities.locations[nodeId],
-              },
-            })
-          }, {})
+        entities.locations = nextLocations
       }
 
       return {
@@ -458,14 +457,17 @@ function useStoreContext() {
   ), [nodeIds])
 
   const topology = useMemo(
-    () =>
-      Object.keys(latencies || {}).reduce(
-        (flattened, nodeId) => ({
-          ...flattened,
-          [nodeId]: Object.keys(latencies[nodeId]),
-        }),
-        {},
-      ),
+    () => {
+      const result: Topology = {}
+
+      const keys = Object.keys(latencies || {})
+
+      for (let i = 0; i < keys.length; ++i) {
+        result[keys[i]] = Object.keys(latencies[keys[i]])
+      }
+
+      return result
+    },
     [latencies],
   )
 

--- a/src/utils/api/tracker.ts
+++ b/src/utils/api/tracker.ts
@@ -107,20 +107,22 @@ export type TopologyResult = Record<string, TopologyEntry[]>
 
 export type StreamTopologyResult = Record<string, TopologyResult>
 
-export const getTopologyFromResponse = (response: TopologyResult): Topology =>
-  Object.keys(response || {}).reduce(
-    (topology: Topology, nodeId: string) => ({
-      ...topology,
-      [nodeId]: (response[nodeId] || []).reduce(
-        (latencies, { neighborId, rtt }) => ({
-          ...latencies,
-          [neighborId]: rtt,
-        }),
-        {},
-      ),
-    }),
-    {},
-  )
+export const getTopologyFromResponse = (response: TopologyResult): Topology => {
+  const result: Topology = {}
+
+  const keys = Object.keys(response || {})
+
+  for (let i = 0; i < keys.length; ++i) {
+    const latencies = response[keys[i]] || []
+
+    result[keys[i]] = {}
+    for (let j = 0; j < latencies.length; ++j) {
+      result[keys[i]][latencies[j].neighborId] = latencies[j].rtt
+    }
+  }
+
+  return result
+}
 
 const isNumber = (value: number | undefined) => typeof value === 'number' && isFinite(value)
 


### PR DESCRIPTION
Improves speed by getting rid of `.reduce` in data methods, this seemed to be the bottle in the browser... This already helps a lot.