### PR TITLE
[FRONT-636] Show list of nodes in the same location

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,8 +35,13 @@ const LayoutComponent = styled.div`
   @media (min-width: ${SM}px) {
     top: 32px !important;
     left: 32px !important;
+
     div > ${ControlBox} + * {
       margin-top: 24px;
+    }
+
+    ${NodeList.Inner} {
+      max-height: calc(100vh - 245px);
     }
   }
 

--- a/src/components/Network/TopologyList.tsx
+++ b/src/components/Network/TopologyList.tsx
@@ -1,31 +1,167 @@
-import React, { useMemo } from 'react'
+import React, {
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useState,
+} from 'react'
+import { useHistory } from 'react-router-dom'
 
 import { useStore } from '../../contexts/Store'
-import NodeList from '../NodeList'
+import { useController } from '../../contexts/Controller'
+import usePaged from '../../hooks/usePaged'
+import { Node } from '../../utils/api/tracker'
+import useIsMounted from '../../hooks/useIsMounted'
 
+import NodeList from '../NodeList'
 import NodeStats from '../NodeStats'
 
 type Props = {
   id?: string
 }
 
-const TopologyList = ({ id }: Props) => {
-  const { nodes } = useStore()
+const TopologyList = ({ id: activeNodeId }: Props) => {
+  const { visibleNodes: nodes } = useStore()
+  const { loadNodeLocations } = useController()
+  const history = useHistory()
+  const listRef = useRef<HTMLDivElement>(null)
+  const scrollTimeout = useRef<number | undefined>(undefined)
+  const [pageChangedOnLoad, setPageChangedOnLoad] = useState(false)
+  const isMounted = useIsMounted()
 
-  const currentNode = useMemo(() => nodes.find(({ id: nodeId }) => nodeId === id), [nodes, id])
-  const { title } = (currentNode || {}).location || {}
+  const currentNode = useMemo(() => nodes.find(({ id: nodeId }) => (
+    nodeId === activeNodeId),
+  ), [nodes, activeNodeId])
 
-  return currentNode ? (
-    <NodeList>
-      <NodeList.Node
-        nodeId={currentNode.id}
-        title={currentNode.title}
-        address={currentNode.address}
-        placeName={title || ''}
-        isActive
-      >
-        <NodeStats key={currentNode.id} id={currentNode.address} />
-      </NodeList.Node>
+  const toggleNode = useCallback(
+    (nodeId) => {
+      history.replace(`/nodes/${encodeURIComponent(nodeId)}`)
+    },
+    [history],
+  )
+
+  // show all nodes in same location
+  const visibleNodes: Node[] = useMemo(() => ((currentNode && nodes) ? (
+    nodes.filter(({ location }) => {
+      const { latitude, longitude } = location
+
+      return (
+        latitude === currentNode.location.latitude &&
+        longitude === currentNode.location.longitude
+      )
+    })
+  ) : []), [nodes, currentNode])
+
+  const {
+    currentPage,
+    setPage,
+    items,
+    pages,
+  } = usePaged<Node>({ items: visibleNodes, limit: NodeList.PAGE_SIZE })
+
+  // Set correct page on load
+  useEffect(() => {
+    if (!activeNodeId || visibleNodes.length < 1 || pageChangedOnLoad) {
+      return
+    }
+
+    const index = visibleNodes.findIndex(({ id: nodeId }) => nodeId === activeNodeId)
+
+    if (index >= 0) {
+      const page = Math.ceil((index + 1) / NodeList.PAGE_SIZE)
+
+      setPage(page)
+      setPageChangedOnLoad(true)
+    }
+  }, [activeNodeId, visibleNodes, setPage, pageChangedOnLoad])
+
+  // set page to 1 if the shown list is empty
+  useEffect(() => {
+    if (visibleNodes.length < 1) {
+      return
+    }
+
+    if (items.length <= 0) {
+      setPage(1)
+    }
+  }, [visibleNodes, items, setPage])
+
+  // scroll active node visible
+  useEffect(() => {
+    const { current: el } = listRef
+
+    if (!el || !activeNodeId || items.length < 1) {
+      return undefined
+    }
+
+    const activeEl = el.querySelector(`[data-node-id="${activeNodeId}"]`)
+
+    if (activeEl) {
+      clearTimeout(scrollTimeout.current)
+
+      scrollTimeout.current = setTimeout(() => {
+        if (isMounted()) {
+          activeEl.scrollIntoView({
+            block: 'start',
+            behavior: 'smooth',
+          })
+        }
+      }, 500)
+    }
+
+    return () => {
+      clearTimeout(scrollTimeout.current)
+    }
+  }, [activeNodeId, items, isMounted])
+
+  // load locations for visible list items
+  const fetching = useRef(false)
+  useEffect(() => {
+    const nodesWithoutLocation = items
+      .filter(({ location }) => location && !location.isReverseGeoCoded)
+
+    if (nodesWithoutLocation.length > 0 && !fetching.current) {
+      fetching.current = true
+      loadNodeLocations(nodesWithoutLocation)
+        .then(() => {
+          fetching.current = false
+        })
+    }
+  }, [items, loadNodeLocations])
+
+  return visibleNodes.length > 0 ? (
+    <NodeList ref={listRef}>
+      {visibleNodes.length > 1 && (
+        <NodeList.Header>
+          There are <strong>{visibleNodes.length}</strong> nodes in this location
+        </NodeList.Header>
+      )}
+      {pages > 1 && (
+        <NodeList.Pager
+          currentPage={currentPage}
+          lastPage={pages}
+          onChange={setPage}
+        />
+      )}
+      {items.map(({
+        id: nodeId,
+        title,
+        address,
+        location,
+      }) => (
+        <NodeList.Node
+          key={nodeId}
+          nodeId={nodeId}
+          title={title}
+          address={address}
+          placeName={(location || {}).title || ''}
+          onClick={toggleNode}
+          isActive={activeNodeId === nodeId}
+          data-node-id={nodeId}
+        >
+          <NodeStats id={address} />
+        </NodeList.Node>
+      ))}
     </NodeList>
   ) : null
 }

--- a/src/components/Network/index.tsx
+++ b/src/components/Network/index.tsx
@@ -98,7 +98,7 @@ export default () => {
       <SearchTextSetter />
       <NodeConnectionsLoader />
       <ActiveNodeSetter id={nodeId} />
-      {!!nodeId && <TopologyList id={nodeId} />}
+      {!!nodeId && <TopologyList id={nodeId} key={nodeId} />}
     </>
   )
 }

--- a/src/components/NodeList/index.tsx
+++ b/src/components/NodeList/index.tsx
@@ -45,9 +45,12 @@ const NodeList = React.forwardRef<HTMLDivElement, Props>(({ children }, ref?) =>
   </ControlBox>
 ))
 
+const PAGE_SIZE = 10
+
 export default Object.assign(NodeList, {
   Inner,
   Header,
   Node: NodeListItem,
   Pager,
+  PAGE_SIZE,
 })

--- a/src/components/Stream/TopologyList.tsx
+++ b/src/components/Stream/TopologyList.tsx
@@ -24,8 +24,6 @@ interface ParamTypes {
   nodeId: string
 }
 
-const PAGE_SIZE = 10
-
 const TopologyList = ({ id }: Props) => {
   const { visibleNodes, stream } = useStore()
   const { nodeId: encodedNodeId } = useParams<ParamTypes>()
@@ -41,7 +39,7 @@ const TopologyList = ({ id }: Props) => {
     setPage,
     items,
     pages,
-  } = usePaged<Node>({ items: visibleNodes, limit: PAGE_SIZE })
+  } = usePaged<Node>({ items: visibleNodes, limit: NodeList.PAGE_SIZE })
 
   const activeNodeId = useMemo(() => (
     encodedNodeId && decodeURIComponent(encodedNodeId)
@@ -71,7 +69,7 @@ const TopologyList = ({ id }: Props) => {
     const index = visibleNodes.findIndex(({ id: nodeId }) => nodeId === activeNodeId)
 
     if (index >= 0) {
-      const page = Math.ceil((index + 1) / PAGE_SIZE)
+      const page = Math.ceil((index + 1) / NodeList.PAGE_SIZE)
 
       setPage(page)
       setPageChangedOnLoad(true)


### PR DESCRIPTION
When clicking on a node in the whole network view, list all nodes with the same longitude and latitude. There is a bit of a jump when choosing an active node but it will scroll to the active spot. Also clicking on an active node won't collapse it as that would hide the whole list. There is some room for UX improvement there 😈 