### PR TITLE
ci: use production environment

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -3,11 +3,17 @@ name: Deploy to production
 on:
   push:
     tags:
-     - v*
+      - v*
+concurrency:
+  group: production
+  cancel-in-progress: true
 
 jobs:  
   deploy:
     name: Build and deploy to production
+    environment:
+      name: production
+      url: https://streamr.network/network-explorer
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Purpose of this PR is to make use of the [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for deployments and to provide a view to [deployment history](https://docs.github.com/en/actions/deployment/managing-your-deployments/viewing-deployment-history).

Concurrency rules for production deployment currently define that the most recent deployment will cancel the currently in progress deployment.

Later [Environment Protection Rules](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-protection-rules) can be used if deemed useful.