### PR TITLE
ci: add concurrency and default shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Lint, test & deploy docker image
 
 on: [push]
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
 
 jobs:
   test:


### PR DESCRIPTION
This PR defines shell as `bash` and concurrency rules for Pull Requests.

When working on PR and pushing a single commit to branch that activates the CI build and then immediately pushing a new commit to the same branch will cancel the build started by the previous push.