### PR TITLE
[FRONT-1871] Polygon Amoy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ethersproject/hdnode": "^5.7.0",
         "@ethersproject/providers": "^5.5.3",
         "@ibm/plex": "^5.1.3",
-        "@streamr/config": "^5.4.0",
+        "@streamr/config": "^5.4.1",
         "@streamr/sdk": "^101.1.2",
         "@streamr/utils": "^101.1.2",
         "@tanstack/react-query": "^5.28.4",
@@ -13933,9 +13933,9 @@
       }
     },
     "node_modules/@streamr/config": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.4.0.tgz",
-      "integrity": "sha512-MdCBFffBRVPgGlaUN6kXfuNWXU20OuK+oQK4YKrdm7bkR/hyx3O78NbH8Mm/LhwQJhKVvl28s+WCr/TgH+uvrw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.4.1.tgz",
+      "integrity": "sha512-m9K44wrQ1fMLLKilh4PZt19tpDsm0e9eSgXom2TFSKvRX/BtY9DpkxlGZNUfaabjlImEouijibIGkGzCcd1kKA=="
     },
     "node_modules/@streamr/dht": {
       "version": "101.1.2",
@@ -50991,9 +50991,9 @@
       }
     },
     "@streamr/config": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.4.0.tgz",
-      "integrity": "sha512-MdCBFffBRVPgGlaUN6kXfuNWXU20OuK+oQK4YKrdm7bkR/hyx3O78NbH8Mm/LhwQJhKVvl28s+WCr/TgH+uvrw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.4.1.tgz",
+      "integrity": "sha512-m9K44wrQ1fMLLKilh4PZt19tpDsm0e9eSgXom2TFSKvRX/BtY9DpkxlGZNUfaabjlImEouijibIGkGzCcd1kKA=="
     },
     "@streamr/dht": {
       "version": "101.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ethersproject/hdnode": "^5.7.0",
     "@ethersproject/providers": "^5.5.3",
     "@ibm/plex": "^5.1.3",
-    "@streamr/config": "^5.4.0",
+    "@streamr/config": "^5.4.1",
     "@streamr/sdk": "^101.1.2",
     "@streamr/utils": "^101.1.2",
     "@tanstack/react-query": "^5.28.4",

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -17,7 +17,7 @@ import { ActiveView, ConnectionsMode, OperatorNode } from './types'
 import { useHud } from './utils'
 import { useOperatorNodesForStreamQuery } from './utils/nodes'
 import { truncate } from './utils/text'
-import { POLYGON_CHAIN_ID } from './utils/chains'
+import { DEFAULT_CHAIN_ID, SUPPORTED_CHAIN_IDS } from './utils/chains'
 
 interface Store {
   chainId: number
@@ -39,7 +39,7 @@ interface Store {
 }
 
 const StoreContext = createContext<Store>({
-  chainId: POLYGON_CHAIN_ID,
+  chainId: DEFAULT_CHAIN_ID,
   activeView: ActiveView.Map,
   connectionsMode: ConnectionsMode.Auto,
   displaySearchPhrase: '',
@@ -61,6 +61,9 @@ interface StoreProviderProps {
   children?: ReactNode
 }
 
+// Add a constant for the storage key
+const CHAIN_ID_STORAGE_KEY = 'network-explorer-chain-id'
+
 export function StoreProvider(props: StoreProviderProps) {
   const selectedNode = useNodeByNodeIdParam()
 
@@ -77,7 +80,17 @@ export function StoreProvider(props: StoreProviderProps) {
     })
   })
 
-  const [chainId, setChainId] = useState(POLYGON_CHAIN_ID)
+  // Initialize chainId from localStorage
+  const [chainId, setChainId] = useState(() => {
+    const stored = localStorage.getItem(CHAIN_ID_STORAGE_KEY)
+
+    // Check if the stored value is a valid network chainId
+    if (stored && SUPPORTED_CHAIN_IDS.includes(parseInt(stored, 10))) {
+      return parseInt(stored, 10)
+    }
+
+    return DEFAULT_CHAIN_ID
+  })
 
   const [activeView, setActiveView] = useState<ActiveView>(ActiveView.Map)
 
@@ -106,7 +119,9 @@ export function StoreProvider(props: StoreProviderProps) {
     [showConnections],
   )
 
+  // Persist chainId changes
   useEffect(() => {
+    localStorage.setItem(CHAIN_ID_STORAGE_KEY, chainId.toString())
     console.log('Store: Chain ID changed:', chainId)
   }, [chainId])
 

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -10,14 +10,18 @@ import React, {
   useReducer,
   useState,
 } from 'react'
-import { useParams } from 'react-router-dom'
 import { DefaultViewState } from './consts'
-import { useGlobalKeyDownEffect, useMap, useStreamIdParam } from './hooks'
+import { useGlobalKeyDownEffect, useMap } from './hooks'
 import { ActiveView, ConnectionsMode, OperatorNode } from './types'
 import { useHud } from './utils'
 import { useOperatorNodesForStreamQuery } from './utils/nodes'
 import { truncate } from './utils/text'
-import { DEFAULT_CHAIN_ID, SUPPORTED_CHAIN_IDS } from './utils/chains'
+import { DEFAULT_CHAIN_ID, getPersistedChainId, persistChainId } from './utils/chains'
+
+interface UrlParams {
+  nodeId: string | null
+  streamId: string | null
+}
 
 interface Store {
   chainId: number
@@ -31,6 +35,8 @@ interface Store {
   publishers: Record<string, string | undefined>
   searchPhrase: string
   selectedNode: OperatorNode | null
+  urlParams: UrlParams
+  setUrlParams(value: UrlParams): void
   setChainId(value: number): void
   setActiveView(value: ActiveView): void
   setConnectionsMode: Dispatch<SetStateAction<ConnectionsMode>>
@@ -50,6 +56,8 @@ const StoreContext = createContext<Store>({
   publishers: {},
   searchPhrase: '',
   selectedNode: null,
+  urlParams: { nodeId: null, streamId: null },
+  setUrlParams: () => {},
   setChainId: () => {},
   setActiveView: () => {},
   setConnectionsMode: () => {},
@@ -61,11 +69,11 @@ interface StoreProviderProps {
   children?: ReactNode
 }
 
-// Add a constant for the storage key
-const CHAIN_ID_STORAGE_KEY = 'network-explorer-chain-id'
-
 export function StoreProvider(props: StoreProviderProps) {
-  const selectedNode = useNodeByNodeIdParam()
+  const [urlParams, setUrlParams] = useState<UrlParams>({
+    nodeId: null,
+    streamId: null,
+  })
 
   const [locationParamKey, invalidateLocationParamKey] = useReducer((x: number) => x + 1, 0)
 
@@ -80,17 +88,7 @@ export function StoreProvider(props: StoreProviderProps) {
     })
   })
 
-  // Initialize chainId from localStorage
-  const [chainId, setChainId] = useState(() => {
-    const stored = localStorage.getItem(CHAIN_ID_STORAGE_KEY)
-
-    // Check if the stored value is a valid network chainId
-    if (stored && SUPPORTED_CHAIN_IDS.includes(parseInt(stored, 10))) {
-      return parseInt(stored, 10)
-    }
-
-    return DEFAULT_CHAIN_ID
-  })
+  const [chainId, setChainId] = useState(getPersistedChainId())
 
   const [activeView, setActiveView] = useState<ActiveView>(ActiveView.Map)
 
@@ -119,11 +117,23 @@ export function StoreProvider(props: StoreProviderProps) {
     [showConnections],
   )
 
-  // Persist chainId changes
   useEffect(() => {
-    localStorage.setItem(CHAIN_ID_STORAGE_KEY, chainId.toString())
-    console.log('Store: Chain ID changed:', chainId)
+    persistChainId(chainId)
   }, [chainId])
+
+  const { streamId, nodeId: activeNodeId } = urlParams
+  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
+
+  const selectedNode = useMemo(
+    function findNodeById() {
+      if (!nodes || !activeNodeId) {
+        return null
+      }
+
+      return nodes.find(({ id }) => id === activeNodeId) || null
+    },
+    [activeNodeId, nodes],
+  )
 
   return (
     <StoreContext.Provider
@@ -140,6 +150,8 @@ export function StoreProvider(props: StoreProviderProps) {
         publishers,
         searchPhrase: rawSearchPhrase,
         selectedNode,
+        urlParams,
+        setUrlParams,
         setChainId,
         setActiveView,
         setConnectionsMode,
@@ -152,23 +164,4 @@ export function StoreProvider(props: StoreProviderProps) {
 
 export function useStore() {
   return useContext(StoreContext)
-}
-
-function useNodeByNodeIdParam() {
-  const streamId = useStreamIdParam()
-
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined)
-
-  const { nodeId: activeNodeId = null } = useParams<{ nodeId: string }>()
-
-  return useMemo(
-    function findNodeById() {
-      if (!nodes || !activeNodeId) {
-        return null
-      }
-
-      return nodes.find(({ id }) => id === activeNodeId) || null
-    },
-    [activeNodeId, nodes],
-  )
 }

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -122,7 +122,7 @@ export function StoreProvider(props: StoreProviderProps) {
   }, [chainId])
 
   const { streamId, nodeId: activeNodeId } = urlParams
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
+  const { data: nodes } = useOperatorNodesForStreamQuery(chainId, streamId || undefined)
 
   const selectedNode = useMemo(
     function findNodeById() {

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -17,8 +17,10 @@ import { ActiveView, ConnectionsMode, OperatorNode } from './types'
 import { useHud } from './utils'
 import { useOperatorNodesForStreamQuery } from './utils/nodes'
 import { truncate } from './utils/text'
+import { POLYGON_CHAIN_ID } from './utils/chains'
 
 interface Store {
+  chainId: number
   activeView: ActiveView
   connectionsMode: ConnectionsMode
   displaySearchPhrase: string
@@ -29,6 +31,7 @@ interface Store {
   publishers: Record<string, string | undefined>
   searchPhrase: string
   selectedNode: OperatorNode | null
+  setChainId(value: number): void
   setActiveView(value: ActiveView): void
   setConnectionsMode: Dispatch<SetStateAction<ConnectionsMode>>
   setPublishers: Dispatch<SetStateAction<Record<string, string | undefined>>>
@@ -36,6 +39,7 @@ interface Store {
 }
 
 const StoreContext = createContext<Store>({
+  chainId: POLYGON_CHAIN_ID,
   activeView: ActiveView.Map,
   connectionsMode: ConnectionsMode.Auto,
   displaySearchPhrase: '',
@@ -46,6 +50,7 @@ const StoreContext = createContext<Store>({
   publishers: {},
   searchPhrase: '',
   selectedNode: null,
+  setChainId: () => {},
   setActiveView: () => {},
   setConnectionsMode: () => {},
   setPublishers: () => ({}),
@@ -71,6 +76,8 @@ export function StoreProvider(props: StoreProviderProps) {
       zoom: DefaultViewState.zoom,
     })
   })
+
+  const [chainId, setChainId] = useState(POLYGON_CHAIN_ID)
 
   const [activeView, setActiveView] = useState<ActiveView>(ActiveView.Map)
 
@@ -99,10 +106,15 @@ export function StoreProvider(props: StoreProviderProps) {
     [showConnections],
   )
 
+  useEffect(() => {
+    console.log('Store: Chain ID changed:', chainId)
+  }, [chainId])
+
   return (
     <StoreContext.Provider
       {...props}
       value={{
+        chainId,
         activeView,
         connectionsMode,
         displaySearchPhrase,
@@ -113,6 +125,7 @@ export function StoreProvider(props: StoreProviderProps) {
         publishers,
         searchPhrase: rawSearchPhrase,
         selectedNode,
+        setChainId,
         setActiveView,
         setConnectionsMode,
         setPublishers,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,7 +52,7 @@ function Page() {
 
   const { chainId } = useStore()
 
-  const isLoadingNodes = useIsFetchingOperatorNodesForStream(streamId || undefined, chainId)
+  const isLoadingNodes = useIsFetchingOperatorNodesForStream(chainId, streamId || undefined)
 
   const { showNetworkSelector, showSearch, compact } = useHud()
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,10 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { MapProvider } from 'react-map-gl'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
-import { StoreProvider } from '../Store'
+import { StoreProvider, useStore } from '../Store'
 import {
   useMap,
   useSelectedNodeLocationEffect,
@@ -33,15 +33,32 @@ const LoadingIndicator = styled(UnstyledLoadingIndicator)`
   z-index: 4;
 `
 
+function UrlParamsSynchronizer() {
+  const { nodeId, streamId } = useParams()
+  const { setUrlParams } = useStore()
+
+  useEffect(() => {
+    setUrlParams({
+      nodeId: nodeId || null,
+      streamId: streamId || null,
+    })
+  }, [nodeId, streamId, setUrlParams])
+
+  return null
+}
+
 function Page() {
   const streamId = useStreamIdParam()
 
-  const isLoadingNodes = useIsFetchingOperatorNodesForStream(streamId || undefined)
+  const { chainId } = useStore()
+
+  const isLoadingNodes = useIsFetchingOperatorNodesForStream(streamId || undefined, chainId)
 
   const { showNetworkSelector, showSearch, compact } = useHud()
 
   return (
     <>
+      <UrlParamsSynchronizer />
       <PublisherDetector />
       <Map />
       <MapAutoUpdater />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -41,7 +41,7 @@ function Page() {
   const { showNetworkSelector, showSearch, compact } = useHud()
 
   return (
-    <StoreProvider>
+    <>
       <PublisherDetector />
       <Map />
       <MapAutoUpdater />
@@ -56,7 +56,7 @@ function Page() {
         <Backdrop />
         <Sidebar />
       </ErrorBoundary>
-    </StoreProvider>
+    </>
   )
 }
 
@@ -126,18 +126,20 @@ export function App() {
   return (
     <BrowserRouter basename={process.env.REACT_APP_BASENAME}>
       <QueryClientProvider client={getQueryClient()}>
-        <StreamrClientProvider>
-          <MapProvider>
-            <Routes>
-              <Route element={<Page />}>
-                <Route path="/streams/:streamId/nodes/:nodeId" element={<StreamTopologyList />} />
-                <Route path="/streams/:streamId" element={<StreamTopologyList />} />
-                <Route path="/nodes/:nodeId" element={<NodeTopologyList />} />
-                <Route index element={<NodeTopologyList />} />
-              </Route>
-            </Routes>
-          </MapProvider>
-        </StreamrClientProvider>
+        <StoreProvider>
+          <StreamrClientProvider>
+            <MapProvider>
+              <Routes>
+                <Route element={<Page />}>
+                  <Route path="/streams/:streamId/nodes/:nodeId" element={<StreamTopologyList />} />
+                  <Route path="/streams/:streamId" element={<StreamTopologyList />} />
+                  <Route path="/nodes/:nodeId" element={<NodeTopologyList />} />
+                  <Route index element={<NodeTopologyList />} />
+                </Route>
+              </Routes>
+            </MapProvider>
+          </StreamrClientProvider>
+        </StoreProvider>
       </QueryClientProvider>
     </BrowserRouter>
   )

--- a/src/components/MapMarkerLayer.tsx
+++ b/src/components/MapMarkerLayer.tsx
@@ -4,13 +4,16 @@ import { useStreamIdParam } from '../hooks'
 import { OperatorNode } from '../types'
 import { NodeLayerId, NodeSourceId, getNodeLocationId } from '../utils/map'
 import { useOperatorNodesForStreamQuery } from '../utils/nodes'
+import { useStore } from '../Store'
 
 const EmptyNodes: OperatorNode[] = []
 
 export function MapMarkerLayer() {
+  const { chainId } = useStore()
+
   const streamId = useStreamIdParam()
 
-  const nodesQuery = useOperatorNodesForStreamQuery(streamId || undefined)
+  const nodesQuery = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
 
   const nodes = nodesQuery.data || EmptyNodes
 

--- a/src/components/MapMarkerLayer.tsx
+++ b/src/components/MapMarkerLayer.tsx
@@ -13,7 +13,7 @@ export function MapMarkerLayer() {
 
   const streamId = useStreamIdParam()
 
-  const nodesQuery = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
+  const nodesQuery = useOperatorNodesForStreamQuery(chainId, streamId || undefined)
 
   const nodes = nodesQuery.data || EmptyNodes
 

--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { SANS } from '../../utils/styled'
 import { Tooltip } from '../Tooltip'
+import { useStore } from '../../Store'
+import { POLYGON_CHAIN_ID, POLYGON_AMOY_CHAIN_ID } from '../../utils/chains'
 
 const GlobeIcon = () => (
   <svg width="18" height="18" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -29,6 +31,10 @@ const TickIcon = () => (
 
 const MainnetTheme = {
   color: '#0EAC1B',
+}
+
+const AmoyTheme = {
+  color: '#FF6B00',
 }
 
 const NetworkIndicator = styled.div`
@@ -120,6 +126,8 @@ const NetworkSelectorRoot = styled.div`
 `
 
 export default function NetworkSelector() {
+  const { chainId, setChainId } = useStore()
+
   const [open, setOpen] = useState<boolean>(false)
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -166,17 +174,28 @@ export default function NetworkSelector() {
       <Tooltip value={!open ? 'Network selector' : undefined}>
         <Button type="button" onClick={toggleOpen}>
           <GlobeIcon />
-          <NetworkIndicator theme={MainnetTheme} />
+          <NetworkIndicator theme={chainId === POLYGON_AMOY_CHAIN_ID ? AmoyTheme : MainnetTheme} />
         </Button>
       </Tooltip>
       {!!open && (
         <NetworkList>
-          <NetworkItem type="button">
+          <NetworkItem type="button" onClick={() => setChainId(POLYGON_CHAIN_ID)}>
             <NetworkIndicator theme={MainnetTheme} />
             <NetworkName>Mainnet</NetworkName>
-            <div>
-              <TickIcon />
-            </div>
+            {chainId === POLYGON_CHAIN_ID && (
+              <div>
+                <TickIcon />
+              </div>
+            )}
+          </NetworkItem>
+          <NetworkItem type="button" onClick={() => setChainId(POLYGON_AMOY_CHAIN_ID)}>
+            <NetworkIndicator theme={AmoyTheme} />
+            <NetworkName>Amoy</NetworkName>
+            {chainId === POLYGON_AMOY_CHAIN_ID && (
+              <div>
+                <TickIcon />
+              </div>
+            )}
           </NetworkItem>
         </NetworkList>
       )}

--- a/src/components/NodeTopologyList.tsx
+++ b/src/components/NodeTopologyList.tsx
@@ -10,7 +10,7 @@ const EmptyNodes: OperatorNode[] = []
 export function NodeTopologyList() {
   const { chainId } = useStore()
 
-  const nodes = useOperatorNodesForStreamQuery(undefined, chainId).data || EmptyNodes
+  const nodes = useOperatorNodesForStreamQuery(chainId, undefined).data || EmptyNodes
 
   const { selectedNode } = useStore()
 

--- a/src/components/NodeTopologyList.tsx
+++ b/src/components/NodeTopologyList.tsx
@@ -8,7 +8,9 @@ import { TopologyList } from './TopologyList'
 const EmptyNodes: OperatorNode[] = []
 
 export function NodeTopologyList() {
-  const nodes = useOperatorNodesForStreamQuery(undefined).data || EmptyNodes
+  const { chainId } = useStore()
+
+  const nodes = useOperatorNodesForStreamQuery(undefined, chainId).data || EmptyNodes
 
   const { selectedNode } = useStore()
 

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -242,8 +242,7 @@ export const Stats = styled(UnstyledStats)`
   position: relative;
 `
 
-function useStreamStatsQuery(streamId: string) {
-  const { chainId } = useStore()
+function useStreamStatsQuery(streamId: string, chainId: number) {
   return useQuery({
     queryKey: ['useStreamStatsQuery', streamId, chainId],
     queryFn: async () => {
@@ -285,7 +284,9 @@ const defaultStreamStats = {
 }
 
 export function StreamStats({ streamId }: StreamStatsProps) {
-  const { data: stats } = useStreamStatsQuery(streamId)
+  const { chainId } = useStore()
+
+  const { data: stats } = useStreamStatsQuery(streamId, chainId)
 
   const { messagesPerSecond, peerCount, latency } = stats || defaultStreamStats
 

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -242,9 +242,9 @@ export const Stats = styled(UnstyledStats)`
   position: relative;
 `
 
-function useStreamStatsQuery(streamId: string, chainId: number) {
+function useStreamStatsQuery(chainId: number, streamId: string) {
   return useQuery({
-    queryKey: ['useStreamStatsQuery', streamId, chainId],
+    queryKey: ['useStreamStatsQuery', chainId, streamId],
     queryFn: async () => {
       const {
         data: { streams },
@@ -286,7 +286,7 @@ const defaultStreamStats = {
 export function StreamStats({ streamId }: StreamStatsProps) {
   const { chainId } = useStore()
 
-  const { data: stats } = useStreamStatsQuery(streamId, chainId)
+  const { data: stats } = useStreamStatsQuery(chainId, streamId)
 
   const { messagesPerSecond, peerCount, latency } = stats || defaultStreamStats
 

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -28,6 +28,7 @@ import { Graphs } from './Graphs'
 import { Interval } from './Graphs/Graphs'
 import { Intervals } from './Graphs/Intervals'
 import { TimeSeries } from './Graphs/TimeSeries'
+import { useStore } from '../Store'
 
 type StatProps = {
   id: string
@@ -242,12 +243,13 @@ export const Stats = styled(UnstyledStats)`
 `
 
 function useStreamStatsQuery(streamId: string) {
+  const { chainId } = useStore()
   return useQuery({
-    queryKey: ['useStreamStatsQuery', streamId],
+    queryKey: ['useStreamStatsQuery', streamId, chainId],
     queryFn: async () => {
       const {
         data: { streams },
-      } = await getIndexerClient().query<GetStreamsQuery, GetStreamsQueryVariables>({
+      } = await getIndexerClient(chainId).query<GetStreamsQuery, GetStreamsQueryVariables>({
         query: GetStreamsDocument,
         variables: {
           ids: [streamId],

--- a/src/components/StreamTopologyList.tsx
+++ b/src/components/StreamTopologyList.tsx
@@ -13,7 +13,7 @@ export function StreamTopologyList() {
 
   const { chainId } = useStore()
 
-  const { data: nodes = [] } = useOperatorNodesForStreamQuery(streamId, chainId)
+  const { data: nodes = [] } = useOperatorNodesForStreamQuery(chainId, streamId || undefined)
 
   const { selectedNode } = useStore()
 

--- a/src/components/StreamTopologyList.tsx
+++ b/src/components/StreamTopologyList.tsx
@@ -11,7 +11,9 @@ export function StreamTopologyList() {
 
   const navigateToNode = useNavigateToNodeCallback()
 
-  const { data: nodes = [] } = useOperatorNodesForStreamQuery(streamId)
+  const { chainId } = useStore()
+
+  const { data: nodes = [] } = useOperatorNodesForStreamQuery(streamId, chainId)
 
   const { selectedNode } = useStore()
 

--- a/src/components/StreamrClientProvider.tsx
+++ b/src/components/StreamrClientProvider.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 import Provider from 'streamr-client-react'
 import { getStreamrClientConfig } from '../utils/streams'
+import { useStore } from '../Store'
 
 interface Props {
   children: React.ReactNode
 }
 
 const StreamrClientProvider = ({ children }: Props) => {
-  const [config] = useState(getStreamrClientConfig())
+  const { chainId } = useStore()
+  const config = useMemo(() => getStreamrClientConfig(chainId), [chainId])
 
   return <Provider {...config}>{children}</Provider>
 }

--- a/src/getters.tsx
+++ b/src/getters.tsx
@@ -13,12 +13,13 @@ import { getIndexerClient } from './utils/queries'
 interface GetOperatorNodesParams {
   ids?: string[]
   streamId?: string
+  chainId: number
 }
 
 export async function getOperatorNodes(params: GetOperatorNodesParams): Promise<OperatorNode[]> {
   const pageSize = 500
 
-  const { ids, streamId } = params
+  const { ids, streamId, chainId } = params
 
   const items: OperatorNode[] = []
 
@@ -27,7 +28,7 @@ export async function getOperatorNodes(params: GetOperatorNodesParams): Promise<
   for (;;) {
     const {
       data: { nodes },
-    } = await getIndexerClient().query<GetNodesQuery, GetNodesQueryVariables>({
+    } = await getIndexerClient(chainId).query<GetNodesQuery, GetNodesQueryVariables>({
       fetchPolicy: 'network-only',
       query: GetNodesDocument,
       variables: {
@@ -70,12 +71,13 @@ interface GetNeighborsParams {
   node?: string
   streamId?: string
   streamPartitionId?: string
+  chainId: number
 }
 
 export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbour[]> {
   const pageSize = 1000
 
-  const { node, streamPartitionId } = params
+  const { node, streamPartitionId, chainId } = params
 
   const items: Neighbour[] = []
 
@@ -86,7 +88,7 @@ export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbou
   for (;;) {
     const {
       data: { neighbors },
-    } = await getIndexerClient().query<GetNeighborsQuery, GetNeighborsQueryVariables>({
+    } = await getIndexerClient(chainId).query<GetNeighborsQuery, GetNeighborsQueryVariables>({
       fetchPolicy: 'network-only',
       query: GetNeighborsDocument,
       variables: {

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -3,7 +3,7 @@ import { config } from '@streamr/config'
 export const POLYGON_CHAIN_ID = config.polygon.id
 export const POLYGON_AMOY_CHAIN_ID = config.polygonAmoy.id
 export const DEFAULT_CHAIN_ID = POLYGON_CHAIN_ID
-export const SUPPORTED_CHAIN_IDS = [POLYGON_CHAIN_ID, POLYGON_AMOY_CHAIN_ID]
+const SUPPORTED_CHAIN_IDS = [POLYGON_CHAIN_ID, POLYGON_AMOY_CHAIN_ID]
 
 const INDEXER_URLS: Record<number, string> = {
   [POLYGON_CHAIN_ID]: 'https://stream-metrics.streamr.network/api',
@@ -16,4 +16,20 @@ export function getIndexerUrl(chainId: number): string {
     throw new Error(`No indexer URL configured for chain ID ${chainId}`)
   }
   return uri
+}
+
+const CHAIN_ID_STORAGE_KEY = 'network-explorer-chain-id'
+
+export function getPersistedChainId(): number {
+  const stored = localStorage.getItem(CHAIN_ID_STORAGE_KEY)
+
+  if (stored && SUPPORTED_CHAIN_IDS.includes(parseInt(stored, 10))) {
+    return parseInt(stored, 10)
+  }
+
+  return DEFAULT_CHAIN_ID
+}
+
+export function persistChainId(chainId: number): void {
+  localStorage.setItem(CHAIN_ID_STORAGE_KEY, chainId.toString())
 }

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,0 +1,17 @@
+import { config } from '@streamr/config'
+
+export const POLYGON_CHAIN_ID = config.polygon.id
+export const POLYGON_AMOY_CHAIN_ID = config.polygonAmoy.id
+
+const INDEXER_URLS: Record<number, string> = {
+  [POLYGON_CHAIN_ID]: 'https://stream-metrics.streamr.network/api',
+  [POLYGON_AMOY_CHAIN_ID]: 'https://stream-metrics-polygonAmoy.streamr.network/api',
+}
+
+export function getIndexerUrl(chainId: number): string {
+  const uri = INDEXER_URLS[chainId]
+  if (!uri) {
+    throw new Error(`No indexer URL configured for chain ID ${chainId}`)
+  }
+  return uri
+}

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -2,6 +2,8 @@ import { config } from '@streamr/config'
 
 export const POLYGON_CHAIN_ID = config.polygon.id
 export const POLYGON_AMOY_CHAIN_ID = config.polygonAmoy.id
+export const DEFAULT_CHAIN_ID = POLYGON_CHAIN_ID
+export const SUPPORTED_CHAIN_IDS = [POLYGON_CHAIN_ID, POLYGON_AMOY_CHAIN_ID]
 
 const INDEXER_URLS: Record<number, string> = {
   [POLYGON_CHAIN_ID]: 'https://stream-metrics.streamr.network/api',

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -11,7 +11,9 @@ import { useOperatorNodesForStreamQuery } from './nodes'
 export function useNodeConnections() {
   const streamId = useStreamIdParam() || undefined
 
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId)
+  const { chainId } = useStore()
+
+  const { data: nodes } = useOperatorNodesForStreamQuery(streamId, chainId)
 
   const { selectedNode } = useStore()
 
@@ -159,7 +161,9 @@ export function useAutoCenterNodeEffect() {
 
   const streamId = useStreamIdParam()
 
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined)
+  const { chainId } = useStore()
+
+  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
 
   const { nodeId: activeNodeId = null } = useParams<{ nodeId: string }>()
 

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -13,7 +13,7 @@ export function useNodeConnections() {
 
   const { chainId } = useStore()
 
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId, chainId)
+  const { data: nodes } = useOperatorNodesForStreamQuery(chainId, streamId || undefined)
 
   const { selectedNode } = useStore()
 
@@ -163,7 +163,7 @@ export function useAutoCenterNodeEffect() {
 
   const { chainId } = useStore()
 
-  const { data: nodes } = useOperatorNodesForStreamQuery(streamId || undefined, chainId)
+  const { data: nodes } = useOperatorNodesForStreamQuery(chainId, streamId || undefined)
 
   const { nodeId: activeNodeId = null } = useParams<{ nodeId: string }>()
 

--- a/src/utils/neighbors.tsx
+++ b/src/utils/neighbors.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { MinuteMs } from '../consts'
 import { getNeighbors } from '../getters'
+import { useStore } from '../Store'
 
-function getOperatorNodeNeighborsQueryKey(nodeId: string | undefined) {
-  return ['useOperatorNodeNeighborsQuery', nodeId || '']
+function getOperatorNodeNeighborsQueryKey(nodeId: string | undefined, chainId: number) {
+  return ['useOperatorNodeNeighborsQuery', nodeId || '', chainId]
 }
 
 interface UseOperatorNodeNeighborsQueryOptions {
@@ -15,13 +16,15 @@ export function useOperatorNodeNeighborsQuery(
   options: UseOperatorNodeNeighborsQueryOptions = {},
 ) {
   const { streamId } = options
+  const { chainId } = useStore()
 
   return useQuery({
-    queryKey: getOperatorNodeNeighborsQueryKey(nodeId),
+    queryKey: getOperatorNodeNeighborsQueryKey(nodeId, chainId),
     queryFn: async () => {
       const neighbours = await getNeighbors({
         node: nodeId,
         streamId,
+        chainId,
       })
 
       if (!streamId) {

--- a/src/utils/neighbors.tsx
+++ b/src/utils/neighbors.tsx
@@ -3,8 +3,8 @@ import { MinuteMs } from '../consts'
 import { getNeighbors } from '../getters'
 import { useStore } from '../Store'
 
-function getOperatorNodeNeighborsQueryKey(nodeId: string | undefined, chainId: number) {
-  return ['useOperatorNodeNeighborsQuery', nodeId || '', chainId]
+function getOperatorNodeNeighborsQueryKey(chainId: number, nodeId: string | undefined) {
+  return ['useOperatorNodeNeighborsQuery', chainId, nodeId || '']
 }
 
 interface UseOperatorNodeNeighborsQueryOptions {
@@ -19,7 +19,7 @@ export function useOperatorNodeNeighborsQuery(
   const { chainId } = useStore()
 
   return useQuery({
-    queryKey: getOperatorNodeNeighborsQueryKey(nodeId, chainId),
+    queryKey: getOperatorNodeNeighborsQueryKey(chainId, nodeId),
     queryFn: async () => {
       const neighbours = await getNeighbors({
         node: nodeId,

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,26 +1,31 @@
 import { useIsFetching, useQuery } from '@tanstack/react-query'
 import { MinuteMs } from '../consts'
 import { getOperatorNodes } from '../getters'
+import { useStore } from '../Store'
 
-function getOperatorNodesForStreamQueryKey(streamId: string | undefined) {
-  return ['useOperatorNodesForStreamQuery', streamId || '']
+function getOperatorNodesForStreamQueryKey(streamId: string | undefined, chainId: number) {
+  return ['useOperatorNodesForStreamQuery', streamId || '', chainId]
 }
 
 export function useOperatorNodesForStreamQuery(streamId: string | undefined) {
+  const { chainId } = useStore()
+
   return useQuery({
-    queryKey: getOperatorNodesForStreamQueryKey(streamId),
+    queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),
     queryFn: () =>
       getOperatorNodes({
         streamId,
+        chainId,
       }),
     staleTime: 5 * MinuteMs,
   })
 }
 
 export function useIsFetchingOperatorNodesForStream(streamId: string | undefined) {
+  const { chainId } = useStore()
   const queryCount = useIsFetching({
     exact: true,
-    queryKey: getOperatorNodesForStreamQueryKey(streamId),
+    queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),
   })
 
   return queryCount > 0

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -2,13 +2,13 @@ import { useIsFetching, useQuery } from '@tanstack/react-query'
 import { MinuteMs } from '../consts'
 import { getOperatorNodes } from '../getters'
 
-function getOperatorNodesForStreamQueryKey(streamId: string | undefined, chainId: number) {
-  return ['useOperatorNodesForStreamQuery', streamId || '', chainId]
+function getOperatorNodesForStreamQueryKey(chainId: number, streamId: string | undefined) {
+  return ['useOperatorNodesForStreamQuery', chainId, streamId || '']
 }
 
-export function useOperatorNodesForStreamQuery(streamId: string | undefined, chainId: number) {
+export function useOperatorNodesForStreamQuery(chainId: number, streamId: string | undefined) {
   return useQuery({
-    queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),
+    queryKey: getOperatorNodesForStreamQueryKey(chainId, streamId),
     queryFn: () =>
       getOperatorNodes({
         streamId,
@@ -18,10 +18,10 @@ export function useOperatorNodesForStreamQuery(streamId: string | undefined, cha
   })
 }
 
-export function useIsFetchingOperatorNodesForStream(streamId: string | undefined, chainId: number) {
+export function useIsFetchingOperatorNodesForStream(chainId: number, streamId: string | undefined) {
   const queryCount = useIsFetching({
     exact: true,
-    queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),
+    queryKey: getOperatorNodesForStreamQueryKey(chainId, streamId),
   })
 
   return queryCount > 0

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,15 +1,12 @@
 import { useIsFetching, useQuery } from '@tanstack/react-query'
 import { MinuteMs } from '../consts'
 import { getOperatorNodes } from '../getters'
-import { useStore } from '../Store'
 
 function getOperatorNodesForStreamQueryKey(streamId: string | undefined, chainId: number) {
   return ['useOperatorNodesForStreamQuery', streamId || '', chainId]
 }
 
-export function useOperatorNodesForStreamQuery(streamId: string | undefined) {
-  const { chainId } = useStore()
-
+export function useOperatorNodesForStreamQuery(streamId: string | undefined, chainId: number) {
   return useQuery({
     queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),
     queryFn: () =>
@@ -21,8 +18,7 @@ export function useOperatorNodesForStreamQuery(streamId: string | undefined) {
   })
 }
 
-export function useIsFetchingOperatorNodesForStream(streamId: string | undefined) {
-  const { chainId } = useStore()
+export function useIsFetchingOperatorNodesForStream(streamId: string | undefined, chainId: number) {
   const queryCount = useIsFetching({
     exact: true,
     queryKey: getOperatorNodesForStreamQueryKey(streamId, chainId),

--- a/src/utils/places.ts
+++ b/src/utils/places.ts
@@ -12,8 +12,8 @@ interface UseLocationFeaturesQueryOptions<T> {
   eligible?: (feature: PlaceFeature) => boolean
 }
 
-function getLocationFeaturesQueryKey(place: string, chainId: number) {
-  return ['useLocationFeaturesQuery', place, chainId]
+function getLocationFeaturesQueryKey(chainId: number, place: string) {
+  return ['useLocationFeaturesQuery', chainId, place]
 }
 
 export function useLocationFeaturesQuery<T = PlaceFeature>(
@@ -26,7 +26,7 @@ export function useLocationFeaturesQuery<T = PlaceFeature>(
   const place = typeof placeParam === 'string' ? placeParam : placeParam.join(',')
 
   return useQuery({
-    queryKey: getLocationFeaturesQueryKey(place, chainId),
+    queryKey: getLocationFeaturesQueryKey(chainId, place),
     queryFn: async ({ signal }) => {
       const result: T[] = []
 
@@ -65,7 +65,7 @@ export function useIsFetchingLocationFeatures(place: string) {
   const { chainId } = useStore()
   const queryCount = useIsFetching({
     exact: true,
-    queryKey: getLocationFeaturesQueryKey(place, chainId),
+    queryKey: getLocationFeaturesQueryKey(chainId, place),
   })
 
   return queryCount > 0

--- a/src/utils/places.ts
+++ b/src/utils/places.ts
@@ -1,6 +1,7 @@
 import { useIsFetching, useQuery } from '@tanstack/react-query'
 import { MapboxToken } from '../consts'
 import { PlaceFeature, PlacesResponse } from '../types'
+import { useStore } from '../Store'
 
 interface UseLocationFeaturesQueryParams {
   place?: string | [number, number]
@@ -11,8 +12,8 @@ interface UseLocationFeaturesQueryOptions<T> {
   eligible?: (feature: PlaceFeature) => boolean
 }
 
-function getLocationFeaturesQueryKey(place: string) {
-  return ['useLocationFeaturesQuery', place]
+function getLocationFeaturesQueryKey(place: string, chainId: number) {
+  return ['useLocationFeaturesQuery', place, chainId]
 }
 
 export function useLocationFeaturesQuery<T = PlaceFeature>(
@@ -20,11 +21,12 @@ export function useLocationFeaturesQuery<T = PlaceFeature>(
   options: UseLocationFeaturesQueryOptions<T> = {},
 ) {
   const { place: placeParam = '' } = params
+  const { chainId } = useStore()
 
   const place = typeof placeParam === 'string' ? placeParam : placeParam.join(',')
 
   return useQuery({
-    queryKey: getLocationFeaturesQueryKey(place),
+    queryKey: getLocationFeaturesQueryKey(place, chainId),
     queryFn: async ({ signal }) => {
       const result: T[] = []
 
@@ -60,9 +62,10 @@ export function useLocationFeaturesQuery<T = PlaceFeature>(
 }
 
 export function useIsFetchingLocationFeatures(place: string) {
+  const { chainId } = useStore()
   const queryCount = useIsFetching({
     exact: true,
-    queryKey: getLocationFeaturesQueryKey(place),
+    queryKey: getLocationFeaturesQueryKey(place, chainId),
   })
 
   return queryCount > 0

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,17 +1,20 @@
 import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client'
 import { QueryClient } from '@tanstack/react-query'
+import { getIndexerUrl } from './chains'
 
-let indexerGraphClient: ApolloClient<NormalizedCacheObject> | undefined
+let indexerGraphClients: Record<number, ApolloClient<NormalizedCacheObject>> = {}
 
-export function getIndexerClient(): ApolloClient<NormalizedCacheObject> {
-  if (!indexerGraphClient) {
-    indexerGraphClient = new ApolloClient({
-      uri: 'https://stream-metrics.streamr.network/api',
+export function getIndexerClient(chainId: number): ApolloClient<NormalizedCacheObject> {
+  if (!indexerGraphClients[chainId]) {
+    const uri = getIndexerUrl(chainId)
+
+    indexerGraphClients[chainId] = new ApolloClient({
+      uri,
       cache: new InMemoryCache(),
     })
   }
 
-  return indexerGraphClient
+  return indexerGraphClients[chainId]
 }
 
 let queryClient: QueryClient | undefined

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -14,7 +14,7 @@ function getValidSearchPhrase(phrase: string) {
 export function useIsSearching(phrase: string) {
   const { chainId } = useStore()
 
-  const isFetchingNodes = useIsFetchingOperatorNodesForStream(undefined, chainId)
+  const isFetchingNodes = useIsFetchingOperatorNodesForStream(chainId, undefined)
 
   const isFetchingPlaces = useIsFetchingLocationFeatures(getValidSearchPhrase(phrase))
 
@@ -24,7 +24,7 @@ export function useIsSearching(phrase: string) {
 export function useSearch({ phrase: phraseParam = '' }) {
   const { chainId } = useStore()
 
-  const nodesQuery = useOperatorNodesForStreamQuery(undefined, chainId)
+  const nodesQuery = useOperatorNodesForStreamQuery(chainId, undefined)
 
   const phrase = useDebounce(getValidSearchPhrase(phraseParam), 250)
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -5,13 +5,16 @@ import { useIsFetchingOperatorNodesForStream, useOperatorNodesForStreamQuery } f
 import { useIsFetchingLocationFeatures, useLocationFeaturesQuery } from './places'
 import { useLimitedStreamsQuery } from './streams'
 import { truncate } from './text'
+import { useStore } from '../Store'
 
 function getValidSearchPhrase(phrase: string) {
   return phrase.length < 3 ? '' : phrase.toLowerCase()
 }
 
 export function useIsSearching(phrase: string) {
-  const isFetchingNodes = useIsFetchingOperatorNodesForStream(undefined)
+  const { chainId } = useStore()
+
+  const isFetchingNodes = useIsFetchingOperatorNodesForStream(undefined, chainId)
 
   const isFetchingPlaces = useIsFetchingLocationFeatures(getValidSearchPhrase(phrase))
 
@@ -19,7 +22,9 @@ export function useIsSearching(phrase: string) {
 }
 
 export function useSearch({ phrase: phraseParam = '' }) {
-  const nodesQuery = useOperatorNodesForStreamQuery(undefined)
+  const { chainId } = useStore()
+
+  const nodesQuery = useOperatorNodesForStreamQuery(undefined, chainId)
 
   const phrase = useDebounce(getValidSearchPhrase(phraseParam), 250)
 

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -193,22 +193,39 @@ export function useRecentOperatorNodeMetricEntry(nodeId: string) {
   return recent
 }
 
+// eslint-disable-next-line import/no-unused-modules
 export function getStreamrClientConfig(chainId: number): StreamrClientConfig {
-  const networkConfig = Object.values(config).find((network) => network.id === chainId)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chainConfig = Object.values(config).find((network) => network.id === chainId) as any
 
-  if (!networkConfig) {
-    throw new Error(`No Streamr Clientconfiguration found for chain ID ${chainId}`)
+  if (!chainConfig) {
+    throw new Error(`No Streamr Client configuration found for chain ID ${chainId}`)
   }
 
-  return {
+  const clientConfig: StreamrClientConfig = {
     metrics: false,
-    contracts: {
-      ethereumNetwork: {
-        chainId: networkConfig.id,
-      },
-      rpcs: networkConfig.rpcEndpoints.slice(0, 1),
-    },
   }
+
+  // Set network entrypoints if provided
+  if (chainConfig.entryPoints && chainConfig.entryPoints.length > 0) {
+    clientConfig.network = {
+      controlLayer: {
+        entryPoints: chainConfig.entryPoints,
+      },
+    }
+  }
+
+  clientConfig.contracts = {
+    ethereumNetwork: {
+      chainId,
+    },
+    rpcs: chainConfig.rpcEndpoints.slice(0, 1),
+    streamRegistryChainAddress: chainConfig.contracts.StreamRegistry,
+    streamStorageRegistryChainAddress: chainConfig.contracts.StreamStorageRegistry,
+    theGraphUrl: chainConfig.theGraphUrl,
+  }
+
+  return clientConfig
 }
 
 async function getStreamrClientInstance(chainId: number) {

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -15,8 +15,8 @@ import {
 import { getIndexerClient } from './queries'
 import { config } from '@streamr/config'
 
-function getLimitedStreamsQueryKey(phrase: string, limit: number, chainId: number) {
-  return ['useLimitedStreamsQuery', phrase, limit, chainId]
+function getLimitedStreamsQueryKey(chainId: number, phrase: string, limit: number) {
+  return ['useLimitedStreamsQuery', chainId, phrase, limit]
 }
 
 interface UseLimitedStreamsQueryParams {
@@ -29,7 +29,7 @@ export function useLimitedStreamsQuery(params: UseLimitedStreamsQueryParams) {
   const { chainId } = useStore()
 
   return useQuery({
-    queryKey: getLimitedStreamsQueryKey(phrase, limit, chainId),
+    queryKey: getLimitedStreamsQueryKey(chainId, phrase, limit),
     queryFn: async () => {
       if (!phrase) {
         return []


### PR DESCRIPTION
This PR adds support for Polygon Amoy network.

- Added network selector UI component with Mainnet/Amoy options
- Implemented selected chain persistence in localStorage
- Updated API clients and queries to use chain-specific endpoints
- Added chain-specific StreamrClient configuration