### PR TITLE
[FRONT-1870] Add stream latency calculation from neighbour RTTs

### DIFF
--- a/src/generated/gql/indexer.ts
+++ b/src/generated/gql/indexer.ts
@@ -35,6 +35,7 @@ export type Neighbor = {
   __typename?: 'Neighbor';
   nodeId1: Scalars['String']['output'];
   nodeId2: Scalars['String']['output'];
+  rtt?: Maybe<Scalars['Int']['output']>;
   streamPartId: Scalars['String']['output'];
 };
 
@@ -171,7 +172,7 @@ export type GetNeighborsQueryVariables = Exact<{
 }>;
 
 
-export type GetNeighborsQuery = { __typename?: 'Query', neighbors: { __typename?: 'Neighbors', cursor?: string | null, items: Array<{ __typename?: 'Neighbor', streamPartId: string, nodeId1: string, nodeId2: string }> } };
+export type GetNeighborsQuery = { __typename?: 'Query', neighbors: { __typename?: 'Neighbors', cursor?: string | null, items: Array<{ __typename?: 'Neighbor', streamPartId: string, nodeId1: string, nodeId2: string, rtt?: number | null }> } };
 
 
 export const GetNodesDocument = gql`
@@ -229,6 +230,7 @@ export const GetNeighborsDocument = gql`
       streamPartId
       nodeId1
       nodeId2
+      rtt
     }
     cursor
   }

--- a/src/getters.tsx
+++ b/src/getters.tsx
@@ -77,7 +77,7 @@ interface GetNeighborsParams {
 export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbour[]> {
   const pageSize = 1000
 
-  const { node, streamPartitionId, chainId } = params
+  const { node, streamId, streamPartitionId, chainId } = params
 
   const items: Neighbour[] = []
 
@@ -95,6 +95,7 @@ export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbou
         cursor,
         node,
         pageSize,
+        streamId,
         streamPart: streamPartitionId,
       },
     })
@@ -103,6 +104,7 @@ export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbou
       nodeId1: a,
       nodeId2: b,
       streamPartId: finalStreamPartitionId,
+      rtt,
     } of neighbors.items) {
       const pair = [a, b].sort() as [string, string]
 
@@ -120,6 +122,7 @@ export async function getNeighbors(params: GetNeighborsParams): Promise<Neighbou
         nodeId0,
         nodeId1,
         streamPartitionId: finalStreamPartitionId,
+        rtt: rtt ?? undefined,
       })
     }
 

--- a/src/queries/indexer.ts
+++ b/src/queries/indexer.ts
@@ -65,6 +65,7 @@ gql`
         streamPartId
         nodeId1
         nodeId2
+        rtt
       }
       cursor
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,7 @@ export interface Neighbour {
   nodeId0: string
   nodeId1: string
   streamPartitionId: string
+  rtt?: number
 }
 
 interface Stream {


### PR DESCRIPTION
Stream latency is visible again and calculated from neighbour RTTs.